### PR TITLE
Add Jorge Mederos from Nethermind

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ Discussion should be open for ~1 week to give members time to review and contrib
  | Lodestar | [Phil Ngo](https://github.com/philknows/) | 1 |
  | Lodestar | [Tuyen Nguyen](https://github.com/tuyennhv/) | 1 |
  | Nethermind | [Daniel Caleda](https://github.com/dceleda/) | 1 |
+ | Nethermind | [Jorge Mederos](https://github.com/jmederosalvarado) | 0.5 |
  | Nethermind | [Kristof Gazso](https://github.com/kristofgaszo/) | 0.5 |
  | Nethermind | [Łukasz Rozmej](https://github.com/LukaszRozmej/) | 1 |
  | Nethermind | [Marcin Sobczak](https://github.com/marcindsobczak/) | 1 |


### PR DESCRIPTION
- Name: Jorge Mederos
- Project: Account Abstraction in Geth & Nethermind Ethereum Client
- Team: Nethermind
- Discord handle: jmederos#5647
- Link to relevant work:
    - Porting Account Abstraction to Geth fork: https://github.com/NethermindEth/mev-aa-geth
    - Working on Nethermind Ethereum client including: Account Abstraction and  The Merge https://github.com/NethermindEth/nethermind/pulls?q=author%3Ajmederosalvarado

- Summary of their work/eligibility: Jorge started working with Nethermind team in December 2021. First, his work concentrated on creating Account Abstraction functionality in Geth fork. After finishing that his focus was on the Nethermind Ethereum Client. Recently he is also part-time involved in a project that is related to L2 and probably out of scope of PG, which is Juno, a StarkNet client: https://github.com/NethermindEth/juno. It was decided by Jorge and the team that he will split his time between Nethermind  Ethereum Client and Juno, hence part-time eligibility is what we are proposing at the moment.