### PR TITLE
Add Holger Drewes as member

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Discussion should be open for ~1 week to give members time to review and contrib
  | EF JavaScript | [Gabriel](https://github.com/gabrocheleau/) | 0.5 |
  | EF JavaScript | [Jochem](https://github.com/jochem-brouwer/) | 0.5 |
  | EF JavaScript | [Scotty Poi](https://github.com/ScottyPoi/) | 1 |
+ | EF JavaScript | [Holger Drewes](https://github.com/holgerd77/) | 1 | 
  | EF Portal | [Jacob Kaufmann](https://github.com/jacobkaufmann/) | 1 |
  | EF Portal | [Jason Carver](https://github.com/carver/) | 1 |
  | EF Portal | [Mike Ferris](https://github.com/mrferris/) | 1 |


### PR DESCRIPTION
Name: Holger Drewes

Project: EthereumJS monorepo

Team: EF Javascript

Discord handle: Holger Drewes#6903

Link to relevant work:

[PRs for EthereumJS Monorepo](https://github.com/ethereumjs/ethereumjs-monorepo/pulls?q=is%3Apr+author%3Aholgerd77+)

Summary of their work/eligibility: Holger is the team lead for the EthereumJS team and has been a lead contributor on the ethereumjs-monorepo with working ranging across the repo (with work extending back to July 2017).  As such, his work touches all areas of protocol work for the EthereumJS suite of tools (with a heavy focus on continual development and upgrade of our VM implementation in Javascript, guiding the team on the implementation of new EIPs, continuing to improve the overall robustness of the library, and overall coordination of our team).