### PR TITLE
Add Gary Rong from the Geth team

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Discussion should be open for ~1 week to give members time to review and contrib
  | EF Geth | [Marius van der Wijden](https://github.com/MariusVanDerWijden/) | 1 |
  | EF Geth | [Matt Garnett](https://github.com/lightclient/) | 1 |
  | EF Geth | [Peter Szilagyi](https://github.com/karalabe/) | 1 |
+ | EF Geth | [Gary Rong](https://github.com/rjl493456442) | 1 |
  | EF Ipsilon | [Andrei Maiboroda](https://github.com/gumb0/) | 1 |
  | EF Ipsilon | [Jose Hugo de la cruz Romero](https://github.com/hugo-dc/) | 0.5 |
  | EF Ipsilon | [Paweł Bylica](https://github.com/chfast/) | 1 |


### PR DESCRIPTION
Name: Gary Rong
Project: Geth 
Team: Geth
Discord: Gary Rong#5629
Github: https://github.com/rjl493456442
Link to relevant work: https://github.com/ethereum/go-ethereum/pulls?q=is%3Apr+author%3Arjl493456442+is%3Aclosed
Summary: Gary has been part of the geth team since 4/2018. He works full time on the code. Right now he's implementing reverse diffs in geth.

