### PR TITLE
Proposal to increase Potuz's weight 0.5 -> 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Discussion should be open for ~1 week to give members time to review and contrib
  | Prysmatic | [James He](https://github.com/james-prysm/) | 1 |
  | Prysmatic | [Kasey Kirkham](https://github.com/kasey/) | 1 |
  | Prysmatic | [Nishant Das](https://github.com/nisdas/) | 1 |
- | Prysmatic | [potuz](https://github.com/potuz/) | 0.5 |
+ | Prysmatic | [potuz](https://github.com/potuz/) | 1 |
  | Prysmatic | [Preston Van Loon](https://github.com/prestonvanloon/) | 1 |
  | Prysmatic | [Radosław Kapka](https://github.com/rkapka/) | 1 |
  | Prysmatic | [Raul Jordan](https://github.com/rauljordan/) | 1 |


### PR DESCRIPTION
Name: @potuz
Project: Prysm
Team: Prysmatic Labs
Discord: potuz#3745

Link to relevant work:
https://github.com/prysmaticlabs/prysm/pulls/potuz
https://github.com/ethereum/execution-apis/pulls?q=is%3Apr+author%3Apotuz+is%3Aclosed

Rationale:
@potuz has been transitioning to a full-time basis for the last 8 months. His official title was part-time due to being a professor at the university but nowadays the professor role has been reduced to just bureaucracy and refereeing. Potuz easily contributes more than 40 hours per week, and In Prysmatic Labs, we have been paying him close to a full-time salary 