### PR TITLE
Add Justin Traglia from EF Security team

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Discussion should be open for ~1 week to give members time to review and contrib
  | EF Security | [Fredrik Svantes](https://github.com/fredriksvantes/) | 1 |
  | EF Security | [Tyler Holmes](https://github.com/z3n-chada/) | 1 |
  | EF Security | [Yoav Weiss](https://github.com/yoavw/) | 1 |
+ | EF Security | [Justin Traglia](https://github.com/jtraglia/) | 1 |
  | EF Testing | [Mario Vega](https://github.com/marioevz/) | 1 |
  | Erigon | [Andrey Ashikhmin](https://github.com/yperbasis/) | 1 |
  | Erigon | [Artem Vorotnikov](https://github.com/vorot93/) | 1 |


### PR DESCRIPTION
Name: Justin Traglia
Project: Ethereum Foundation
Team: Security Research
Discord: jtraglia#5194
Link to relevant work: https://github.com/jtraglia
Summary: Justin is working full time and has been with the EF since February 1st (he would thus be eligible to join August 1st when the new period starts). Some of his work can be seen in his commits to Teku (https://github.com/ConsenSys/teku/commits?author=jtraglia), mev-boost (flashbots/mev-boost#192) and more at https://github.com/jtraglia