### PR TITLE
Add Dmitry Shmatko from Teku

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ Discussion should be open for ~1 week to give members time to review and contrib
  | Teku | [Adrian Sutton](https://github.com/ajsutton/) | 1 |
  | Teku | [Ben Edgington](https://github.com/benjaminion/) | 1 |
  | Teku | [Courtney Hunter](https://github.com/courtneyeh/) | 1 |
+ | Teku | [Dmitry Shmatko](https://github.com/zilm13) | 1 |
  | Teku | [Enrico Del Fante](https://github.com/tbenr/) | 1 |
  | Teku | [Paul Harris](https://github.com/rolfyone/) | 1 |
  | TXRX | [Alex Vlasov](https://github.com/ericsson49/) | 1 |


### PR DESCRIPTION
Name: Dmitry Shmatko
Project: Teku
Discord: zilm#3277
Link to relevant work: https://github.com/zilm13
Summary: Dmitry joined the Teku dev team in January 2022 and has passed the six month eligibility period. He was previously with TX/RX, and the Harmony Eth2 client project before that.