### PR TITLE
Add Anders Elowsson

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Discussion should be open for ~1 week to give members time to review and contrib
  | EF Research | [Zhenfei Zhang](https://github.com/zhenfeizhang/) | 0.5 |
  | EF Robust Incentives Group (RIG) | [Barnabé Monnot](https://github.com/barnabemonnot/) | 1 |
  | EF Robust Incentives Group (RIG) | [Caspar Schwarz-Schilling](https://github.com/casparschwa/) | 1 |
- | EF Robust Incentives Group (RIG) | [Anders Elowsson](https://twitter.com/weboftrees) | 1 |
+ | EF Robust Incentives Group (RIG) | [Anders Elowsson](https://ethresear.ch/u/aelowsson/summary) | 1 |
  | EF Security | [David Theodore](https://github.com/infosecual/) | 1 |
  | EF Security | [Fredrik Svantes](https://github.com/fredriksvantes/) | 1 |
  | EF Security | [Tyler Holmes](https://github.com/z3n-chada/) | 1 |


### PR DESCRIPTION
## Name / identifier

Anders Elowsson

## Team

Robust Incentives Group (RIG) @ Ethereum Foundation

## Link to some work

- [Original Ethresearch post on circulating supply dynamics](https://ethresear.ch/t/circulating-supply-equilibrium-for-ethereum-and-minimum-viable-issuance-during-the-proof-of-stake-era/10954)
- [ETHconomics talk](https://www.youtube.com/watch?v=LtEMabS0Oas)

## Short summary of their work / eligibility

Anders joined our team on January 1st, 2022. Since joining, he has been working on an expanded version of the ethresearch post cited above, which formalises further his ideas around maximum viable deflation, discouragement attacks and general economics of Proof-of-Stake Ethereum. While the paper is currently unreleased, work progresses at a good pace and I have no doubt Anders is looking to expand and continue contributing beyond.

Internally at EF, Anders has contributed to many discussions, including receiving a "hat tip" in Vitalik's latest [validator set size capping](https://notes.ethereum.org/@vbuterin/validator_set_size_capping), a topic Anders is actively researching. He is also active in internal team discussions.