### PR TITLE
Removal of Lodestar member Dadepo Aderemi

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,134 +23,133 @@ Discussion should be open for ~1 week to give members time to review and contrib
 
 | | Team  |                Name / Link to work |  Multiplier |
 | ---: | :---        |        :--- |        :--- |
-| 	1	| 0xSplits | [donations.0xSplits.eth](https://github.com/0xSplits/) | 1 |
-| 	2	| Akula | [Artem Vorotnikov](https://github.com/vorot93/) | 1 |
-| 	3	| EF DevOps | [Parithosh Jayanthi](https://github.com/parithosh/) | 1 |
-| 	4	| EF DevOps | [Rafael Matias](https://github.com/skylenet/) | 0.5 |
-| 	5	| EF DevOps | [Sam Calder-Mason](https://github.com/samcm/) | 1 |
-| 	6	| EF Geth | [Gary Rong](https://github.com/rjl493456442/) | 1 |
-| 	7	| EF Geth | [Guillaume Ballet](https://github.com/gballet/) | 1 |
-| 	8	| EF Geth | [Jared Wasinger](https://github.com/jwasinger/) | 1 |
-| 	9	| EF Geth | [Marius van der Wijden](https://github.com/MariusVanDerWijden/) | 1 |
-| 	10	| EF Geth | [Matt Garnett](https://github.com/lightclient/) | 1 |
-| 	11	| EF Geth | [Peter Szilagyi](https://github.com/karalabe/) | 1 |
-| 	12	| EF Ipsilon | [Andrei Maiboroda](https://github.com/gumb0/) | 1 |
-| 	13	| EF Ipsilon | [Jose Hugo de la cruz Romero](https://github.com/hugo-dc/) | 0.5 |
-| 	14	| EF Ipsilon | [Paweł Bylica](https://github.com/chfast/) | 1 |
-| 	15	| EF JavaScript | [Andrew Day](https://github.com/acolytec3/) | 1 |
-| 	16	| EF JavaScript | [Gabriel](https://github.com/gabrocheleau/) | 0.5 |
-| 	17	| EF JavaScript | [Holger Drewes](https://github.com/holgerd77/) | 0.5 |
-| 	18	| EF JavaScript | [Jochem](https://github.com/jochem-brouwer/) | 0.5 |
-| 	19	| EF JavaScript | [Scotty Poi](https://github.com/ScottyPoi/) | 1 |
-| 	20	| EF Portal | [Jacob Kaufmann](https://github.com/jacobkaufmann/) | 1 |
-| 	21	| EF Portal | [Jason Carver](https://github.com/carver/) | 1 |
-| 	22	| EF Portal | [Mike Ferris](https://github.com/mrferris/) | 1 |
-| 	23	| EF Portal | [Ognyan Genev](https://github.com/ogenev/) | 1 |
-| 	24	| EF Portal | [Piper Merriam](https://github.com/pipermerriam/) | 1 |
-| 	25	| EF Privacy & Scaling Explorations (PSE) | [Kevaundray](https://github.com/kevaundray/) | 1 |
-| 	26	| EF Protocol Support | [Danny Ryan](https://github.com/djrtwo/) | 1 |
-| 	27	| EF Protocol Support | [Sam Wilson](https://github.com/SamWilsn/) | 1 |
-| 	28	| EF Protocol Support | [Tim Beiko](https://github.com/timbeiko/) | 1 |
-| 	29	| EF Protocol Support | [Trenton Van Epps](https://github.com/tvanepps/) | 1 |
-| 	30	| EF Research | [Aditya Asgaonkar](https://github.com/adiasg/) | 1 |
-| 	31	| EF Research | [Alex Stokes](https://github.com/ralexstokes/) | 1 |
-| 	32	| EF Research | [Ansgar Dietrichs](https://github.com/adietrichs/) | 1 |
-| 	33	| EF Research | [Antonio Sanso](https://github.com/asanso/) | 1 |
-| 	34	| EF Research | [Carl Beekhuizen](https://github.com/CarlBeek/) | 1 |
-| 	35	| EF Research | [Dankrad Feist](https://github.com/dankrad/) | 1 |
-| 	36	| EF Research | [Dmitry Khovratovich](https://github.com/khovratovich/) | 1 |
-| 	37	| EF Research | [Francesco d’Amato](https://github.com/notes.ethereum.org/@fradamt/) | 1 |
-| 	38	| EF Research | [George Kadianakis](https://github.com/asn-d6/) | 1 |
-| 	39	| EF Research | [Hsiao Wei Wang](https://github.com/hwwhww/) | 1 |
-| 	40	| EF Research | [Justin Drake](https://github.com/justindrake/) | 1 |
-| 	41	| EF Research | [Mark Simkin](https://github.com/msimkin.github.io/) | 1 |
-| 	42	| EF Research | [Proto](https://github.com/protolambda/) | 0.5 |
-| 	43	| EF Research | [Zhenfei Zhang](https://github.com/zhenfeizhang/) | 0.5 |
-| 	44	| EF Robust Incentives Group (RIG) | [Anders](https://github.com/anderselowsson/) | 1 |
-| 	45	| EF Robust Incentives Group (RIG) | [Barnabé Monnot](https://github.com/barnabemonnot/) | 1 |
-| 	46	| EF Robust Incentives Group (RIG) | [Caspar Schwarz-Schilling](https://github.com/casparschwa/) | 1 |
-| 	47	| EF Security | [David Theodore](https://github.com/infosecual/) | 1 |
-| 	48	| EF Security | [Fredrik Svantes](https://github.com/fredriksvantes/) | 1 |
-| 	49	| EF Security | [Justin Traglia](https://github.com/jtraglia/) | 1 |
-| 	50	| EF Security | [Tyler Holmes](https://github.com/z3n-chada/) | 1 |
-| 	51	| EF Security | [Yoav Weiss](https://github.com/yoavw/) | 1 |
-| 	52	| EF Solidity | [Alex Beregszaszi](https://github.com/axic/) | 1 |
-| 	53	| EF Solidity | [Daniel Kirchner](https://github.com/ekpyron/) | 0.5 |
-| 	54	| EF Solidity | [Harikrishnan Mulackal](https://github.com/hrkrshnn/) | 0.5 |
-| 	55	| EF Solidity | [Kaan Uzdogan](https://github.com/kuzdogan/) | 1 |
-| 	56	| EF Solidity | [Kamil Sliwak](https://github.com/cameel/) | 1 |
-| 	57	| EF Solidity | [Leonardo de Sa Alt](https://github.com/leonardoalt/) | 1 |
-| 	58	| EF Testing | [Mario Vega](https://github.com/marioevz/) | 1 |
-| 	59	| Erigon | [Alex Sharov](https://github.com/AskAlexSharov/) | 1 |
-| 	60	| Erigon | [Andrey Ashikhmin](https://github.com/yperbasis/) | 1 |
-| 	61	| Erigon | [Enrique Avila Asapche](https://github.com/enriavil1/) | 1 |
-| 	62	| Erigon | [Giulio rebuffo](https://github.com/Giulio2002/) | 1 |
-| 	63	| Erigon | [Michelangelo Riccobene](https://github.com/mriccobene/) | 0.5 |
-| 	64	| Erigon | [Tullio Canepa](https://github.com/canepat/) | 1 |
-| 	65	| Ethereum Cat Herders | [Pooja Ranjan](https://github.com/poojaranjan/) | 1 |
-| 	66	| Hyperledger Besu | [Ameziane](https://github.com/https://github.com/ahamlat/) | 1 |
-| 	67	| Hyperledger Besu | [Daniel Lehrner](https://github.com/daniellehrner/) | 1 |
-| 	68	| Hyperledger Besu | [Danno Ferrin](https://github.com/shemnon/) | 1 |
-| 	69	| Hyperledger Besu | [Fabio di Fabio](https://github.com/fab-10/) | 1 |
-| 	70	| Hyperledger Besu | [Gary Schulte](https://github.com/garyschulte/) | 1 |
-| 	71	| Hyperledger Besu | [Jiri Peinlich](https://github.com/gezero/) | 1 |
-| 	72	| Hyperledger Besu | [Justin Florentine](https://github.com/jflo/) | 1 |
-| 	73	| Hyperledger Besu | [Karim Taam](https://github.com/matkt/) | 1 |
-| 	74	| Independent | [Guru](https://github.com/gurukamath/) | 0.5 |
-| 	75	| Independent | [Jim mcDonald](https://github.com/mcdee/) | 0.5 |
-| 	76	| Independent | [Peter Davies](https://github.com/ultratwo/) | 1 |
-| 	77	| Lighthouse | [Adrian Manning](https://github.com/AgeManning/) | 1 |
-| 	78	| Lighthouse | [Diva Martínez](https://github.com/divagant-martian/) | 1 |
-| 	79	| Lighthouse | [Mac Ladson](https://github.com/macladson/) | 1 |
-| 	80	| Lighthouse | [Mark Mackey](https://github.com/ethDreamer/) | 1 |
-| 	81	| Lighthouse | [Mehdi Zerouali](https://github.com/zedt3ster/) | 1 |
-| 	82	| Lighthouse | [Michael Sproul](https://github.com/michaelsproul/) | 1 |
-| 	83	| Lighthouse | [Paul Hauner](https://github.com/paulhauner/) | 1 |
-| 	84	| Lighthouse | [Pawan Dhananjay Ravi](https://github.com/pawanjay176/) | 1 |
-| 	85	| Lighthouse | [Sean Anderson](https://github.com/realbigsean/) | 1 |
-| 	86	| Lodestar | [Afri](https://github.com/q9f/) | 0.5 |
-| 	87	| Lodestar | [Cayman Nava](https://github.com/wemeetagain/) | 1 |
-| 	88	| Lodestar | [Dadepo Aderemi](https://github.com/dadepo/) | 1 |
-| 	89	| Lodestar | [dapplion](https://github.com/dapplion/) | 1 |
-| 	90	| Lodestar | [Gajinder Singh](https://github.com/g11tech/) | 1 |
-| 	91	| Lodestar | [Phil Ngo](https://github.com/philknows/) | 1 |
-| 	92	| Lodestar | [Tuyen Nguyen](https://github.com/tuyennhv/) | 1 |
-| 	93	| Nethermind | [Daniel Celeda](https://github.com/dceleda/) | 1 |
-| 	94	| Nethermind | [Jorge Mederos](https://github.com/jmederosalvarado/) | 0.5 |
-| 	95	| Nethermind | [Łukasz Rozmej](https://github.com/LukaszRozmej/) | 1 |
-| 	96	| Nethermind | [Marcin Sobczak](https://github.com/marcindsobczak/) | 1 |
-| 	97	| Nethermind | [Marek Moraczyński](https://github.com/MarekM25/) | 1 |
-| 	98	| Nethermind | [Mateusz Jędrzejewski](https://github.com/matilote/) | 0.5 |
-| 	99	| Nethermind | [Tanishq](https://github.com/tanishqjasoria/) | 1 |
-| 	100	| Nethermind | [Tomasz Stanzeck](https://github.com/tkstanczak/) | 0.5 |
-| 	101	| Prysmatic | [James He](https://github.com/james-prysm/) | 1 |
-| 	102	| Prysmatic | [Kasey Kirkham](https://github.com/kasey/) | 1 |
-| 	103	| Prysmatic | [Nishant Das](https://github.com/nisdas/) | 1 |
-| 	104	| Prysmatic | [potuz](https://github.com/potuz/) | 1 |
-| 	105	| Prysmatic | [Preston Van Loon](https://github.com/prestonvanloon/) | 1 |
-| 	106	| Prysmatic | [Radosław Kapka](https://github.com/rkapka/) | 1 |
-| 	107	| Prysmatic | [Raul Jordan](https://github.com/rauljordan/) | 1 |
-| 	108	| Prysmatic | [Taran Singh](https://github.com/Taranpreet26311/) | 1 |
-| 	109	| Prysmatic | [Terence Tsao](https://github.com/terencechain/) | 1 |
-| 	110	| Status | [Dustin Brody](https://github.com/tersec/) | 1 |
-| 	111	| Status | [Etan Kissling](https://github.com/etan-status/) | 1 |
-| 	112	| Status | [Eugene Kabanov](https://github.com/cheatfate/) | 1 |
-| 	113	| Status | [Jacek Sieka](https://github.com/arnetheduck/) | 1 |
-| 	114	| Status | [Jordan Hrycaj](https://github.com/mjfh/) | 1 |
-| 	115	| Status | [Kim De Mey](https://github.com/kdeme/) | 1 |
-| 	116	| Status | [Konrad Staniec](https://github.com/KonradStaniec/) | 1 |
-| 	117	| Status | [Mamy Ratsimbazafy](https://github.com/mratsim/) | 1 |
-| 	118	| Status | [Zahary Karadzhov](https://github.com/zah/) | 1 |
-| 	119	| Teku | [Adrian Sutton](https://github.com/ajsutton/) | 1 |
-| 	120	| Teku | [Ben Edgington](https://github.com/benjaminion/) | 1 |
-| 	121	| Teku | [Courtney Hunter](https://github.com/courtneyeh/) | 1 |
-| 	122	| Teku | [Dmitry Shmatko](https://github.com/zilm13/) | 1 |
-| 	123	| Teku | [Enrico Del Fante](https://github.com/tbenr/) | 1 |
-| 	124	| Teku | [Paul Harris](https://github.com/rolfyone/) | 1 |
-| 	125	| Teku | [Stefan Bratanov](https://github.com/StefanBratanov/) | 1 |
-| 	126	| TXRX | [Alex Vlasov](https://github.com/ericsson49/) | 1 |
-| 	127	| TXRX | [Anton Nashatyrev](https://github.com/Nashatyrev/) | 1 |
-| 	128	| TXRX | [Mikhail Kalinin](https://github.com/mkalinin/) | 1 |
+|	1	| 0xSplits | [donations.0xSplits.eth](https://github.com/0xSplits/) | 1 |
+|	2	| Akula | [Artem Vorotnikov](https://github.com/vorot93/) | 1 |
+|	3	| EF DevOps | [Parithosh Jayanthi](https://github.com/parithosh/) | 1 |
+|	4	| EF DevOps | [Rafael Matias](https://github.com/skylenet/) | 0.5 |
+|	5	| EF DevOps | [Sam Calder-Mason](https://github.com/samcm/) | 1 |
+|	6	| EF Geth | [Gary Rong](https://github.com/rjl493456442/) | 1 |
+|	7	| EF Geth | [Guillaume Ballet](https://github.com/gballet/) | 1 |
+|	8	| EF Geth | [Jared Wasinger](https://github.com/jwasinger/) | 1 |
+|	9	| EF Geth | [Marius van der Wijden](https://github.com/MariusVanDerWijden/) | 1 |
+|	10	| EF Geth | [Matt Garnett](https://github.com/lightclient/) | 1 |
+|	11	| EF Geth | [Peter Szilagyi](https://github.com/karalabe/) | 1 |
+|	12	| EF Ipsilon | [Andrei Maiboroda](https://github.com/gumb0/) | 1 |
+|	13	| EF Ipsilon | [Jose Hugo de la cruz Romero](https://github.com/hugo-dc/) | 0.5 |
+|	14	| EF Ipsilon | [Paweł Bylica](https://github.com/chfast/) | 1 |
+|	15	| EF JavaScript | [Andrew Day](https://github.com/acolytec3/) | 1 |
+|	16	| EF JavaScript | [Gabriel](https://github.com/gabrocheleau/) | 0.5 |
+|	17	| EF JavaScript | [Holger Drewes](https://github.com/holgerd77/) | 0.5 |
+|	18	| EF JavaScript | [Jochem](https://github.com/jochem-brouwer/) | 0.5 |
+|	19	| EF JavaScript | [Scotty Poi](https://github.com/ScottyPoi/) | 1 |
+|	20	| EF Portal | [Jacob Kaufmann](https://github.com/jacobkaufmann/) | 1 |
+|	21	| EF Portal | [Jason Carver](https://github.com/carver/) | 1 |
+|	22	| EF Portal | [Mike Ferris](https://github.com/mrferris/) | 1 |
+|	23	| EF Portal | [Ognyan Genev](https://github.com/ogenev/) | 1 |
+|	24	| EF Portal | [Piper Merriam](https://github.com/pipermerriam/) | 1 |
+|	25	| EF Privacy & Scaling Explorations (PSE) | [Kevaundray](https://github.com/kevaundray/) | 1 |
+|	26	| EF Protocol Support | [Danny Ryan](https://github.com/djrtwo/) | 1 |
+|	27	| EF Protocol Support | [Sam Wilson](https://github.com/SamWilsn/) | 1 |
+|	28	| EF Protocol Support | [Tim Beiko](https://github.com/timbeiko/) | 1 |
+|	29	| EF Protocol Support | [Trenton Van Epps](https://github.com/tvanepps/) | 1 |
+|	30	| EF Research | [Aditya Asgaonkar](https://github.com/adiasg/) | 1 |
+|	31	| EF Research | [Alex Stokes](https://github.com/ralexstokes/) | 1 |
+|	32	| EF Research | [Ansgar Dietrichs](https://github.com/adietrichs/) | 1 |
+|	33	| EF Research | [Antonio Sanso](https://github.com/asanso/) | 1 |
+|	34	| EF Research | [Carl Beekhuizen](https://github.com/CarlBeek/) | 1 |
+|	35	| EF Research | [Dankrad Feist](https://github.com/dankrad/) | 1 |
+|	36	| EF Research | [Dmitry Khovratovich](https://github.com/khovratovich/) | 1 |
+|	37	| EF Research | [Francesco d’Amato](https://github.com/notes.ethereum.org/@fradamt/) | 1 |
+|	38	| EF Research | [George Kadianakis](https://github.com/asn-d6/) | 1 |
+|	39	| EF Research | [Hsiao Wei Wang](https://github.com/hwwhww/) | 1 |
+|	40	| EF Research | [Justin Drake](https://github.com/justindrake/) | 1 |
+|	41	| EF Research | [Mark Simkin](https://github.com/msimkin.github.io/) | 1 |
+|	42	| EF Research | [Proto](https://github.com/protolambda/) | 0.5 |
+|	43	| EF Research | [Zhenfei Zhang](https://github.com/zhenfeizhang/) | 0.5 |
+|	44	| EF Robust Incentives Group (RIG) | [Anders](https://github.com/anderselowsson/) | 1 |
+|	45	| EF Robust Incentives Group (RIG) | [Barnabé Monnot](https://github.com/barnabemonnot/) | 1 |
+|	46	| EF Robust Incentives Group (RIG) | [Caspar Schwarz-Schilling](https://github.com/casparschwa/) | 1 |
+|	47	| EF Security | [David Theodore](https://github.com/infosecual/) | 1 |
+|	48	| EF Security | [Fredrik Svantes](https://github.com/fredriksvantes/) | 1 |
+|	49	| EF Security | [Justin Traglia](https://github.com/jtraglia/) | 1 |
+|	50	| EF Security | [Tyler Holmes](https://github.com/z3n-chada/) | 1 |
+|	51	| EF Security | [Yoav Weiss](https://github.com/yoavw/) | 1 |
+|	52	| EF Solidity | [Alex Beregszaszi](https://github.com/axic/) | 1 |
+|	53	| EF Solidity | [Daniel Kirchner](https://github.com/ekpyron/) | 0.5 |
+|	54	| EF Solidity | [Harikrishnan Mulackal](https://github.com/hrkrshnn/) | 0.5 |
+|	55	| EF Solidity | [Kaan Uzdogan](https://github.com/kuzdogan/) | 1 |
+|	56	| EF Solidity | [Kamil Sliwak](https://github.com/cameel/) | 1 |
+|	57	| EF Solidity | [Leonardo de Sa Alt](https://github.com/leonardoalt/) | 1 |
+|	58	| EF Testing | [Mario Vega](https://github.com/marioevz/) | 1 |
+|	59	| Erigon | [Alex Sharov](https://github.com/AskAlexSharov/) | 1 |
+|	60	| Erigon | [Andrey Ashikhmin](https://github.com/yperbasis/) | 1 |
+|	61	| Erigon | [Enrique Avila Asapche](https://github.com/enriavil1/) | 1 |
+|	62	| Erigon | [Giulio rebuffo](https://github.com/Giulio2002/) | 1 |
+|	63	| Erigon | [Michelangelo Riccobene](https://github.com/mriccobene/) | 0.5 |
+|	64	| Erigon | [Tullio Canepa](https://github.com/canepat/) | 1 |
+|	65	| Ethereum Cat Herders | [Pooja Ranjan](https://github.com/poojaranjan/) | 1 |
+|	66	| Hyperledger Besu | [Ameziane](https://github.com/https://github.com/ahamlat/) | 1 |
+|	67	| Hyperledger Besu | [Daniel Lehrner](https://github.com/daniellehrner/) | 1 |
+|	68	| Hyperledger Besu | [Danno Ferrin](https://github.com/shemnon/) | 1 |
+|	69	| Hyperledger Besu | [Fabio di Fabio](https://github.com/fab-10/) | 1 |
+|	70	| Hyperledger Besu | [Gary Schulte](https://github.com/garyschulte/) | 1 |
+|	71	| Hyperledger Besu | [Jiri Peinlich](https://github.com/gezero/) | 1 |
+|	72	| Hyperledger Besu | [Justin Florentine](https://github.com/jflo/) | 1 |
+|	73	| Hyperledger Besu | [Karim Taam](https://github.com/matkt/) | 1 |
+|	74	| Independent | [Guru](https://github.com/gurukamath/) | 0.5 |
+|	75	| Independent | [Jim mcDonald](https://github.com/mcdee/) | 0.5 |
+|	76	| Independent | [Peter Davies](https://github.com/ultratwo/) | 1 |
+|	77	| Lighthouse | [Adrian Manning](https://github.com/AgeManning/) | 1 |
+|	78	| Lighthouse | [Diva Martínez](https://github.com/divagant-martian/) | 1 |
+|	79	| Lighthouse | [Mac Ladson](https://github.com/macladson/) | 1 |
+|	80	| Lighthouse | [Mark Mackey](https://github.com/ethDreamer/) | 1 |
+|	81	| Lighthouse | [Mehdi Zerouali](https://github.com/zedt3ster/) | 1 |
+|	82	| Lighthouse | [Michael Sproul](https://github.com/michaelsproul/) | 1 |
+|	83	| Lighthouse | [Paul Hauner](https://github.com/paulhauner/) | 1 |
+|	84	| Lighthouse | [Pawan Dhananjay Ravi](https://github.com/pawanjay176/) | 1 |
+|	85	| Lighthouse | [Sean Anderson](https://github.com/realbigsean/) | 1 |
+|	86	| Lodestar | [Afri](https://github.com/q9f/) | 0.5 |
+|	87	| Lodestar | [Cayman Nava](https://github.com/wemeetagain/) | 1 |
+|	88	| Lodestar | [dapplion](https://github.com/dapplion/) | 1 |
+|	89	| Lodestar | [Gajinder Singh](https://github.com/g11tech/) | 1 |
+|	90	| Lodestar | [Phil Ngo](https://github.com/philknows/) | 1 |
+|	91	| Lodestar | [Tuyen Nguyen](https://github.com/tuyennhv/) | 1 |
+|	92	| Nethermind | [Daniel Celeda](https://github.com/dceleda/) | 1 |
+|	93	| Nethermind | [Jorge Mederos](https://github.com/jmederosalvarado/) | 0.5 |
+|	94	| Nethermind | [Łukasz Rozmej](https://github.com/LukaszRozmej/) | 1 |
+|	95	| Nethermind | [Marcin Sobczak](https://github.com/marcindsobczak/) | 1 |
+|	96	| Nethermind | [Marek Moraczyński](https://github.com/MarekM25/) | 1 |
+|	97	| Nethermind | [Mateusz Jędrzejewski](https://github.com/matilote/) | 0.5 |
+|	98	| Nethermind | [Tanishq](https://github.com/tanishqjasoria/) | 1 |
+|	99	| Nethermind | [Tomasz Stanzeck](https://github.com/tkstanczak/) | 0.5 |
+|	100	| Prysmatic | [James He](https://github.com/james-prysm/) | 1 |
+|	101	| Prysmatic | [Kasey Kirkham](https://github.com/kasey/) | 1 |
+|	102	| Prysmatic | [Nishant Das](https://github.com/nisdas/) | 1 |
+|	103	| Prysmatic | [potuz](https://github.com/potuz/) | 1 |
+|	104	| Prysmatic | [Preston Van Loon](https://github.com/prestonvanloon/) | 1 |
+|	105	| Prysmatic | [Radosław Kapka](https://github.com/rkapka/) | 1 |
+|	106	| Prysmatic | [Raul Jordan](https://github.com/rauljordan/) | 1 |
+|	107	| Prysmatic | [Taran Singh](https://github.com/Taranpreet26311/) | 1 |
+|	108	| Prysmatic | [Terence Tsao](https://github.com/terencechain/) | 1 |
+|	109	| Status | [Dustin Brody](https://github.com/tersec/) | 1 |
+|	110	| Status | [Etan Kissling](https://github.com/etan-status/) | 1 |
+|	111	| Status | [Eugene Kabanov](https://github.com/cheatfate/) | 1 |
+|	112	| Status | [Jacek Sieka](https://github.com/arnetheduck/) | 1 |
+|	113	| Status | [Jordan Hrycaj](https://github.com/mjfh/) | 1 |
+|	114	| Status | [Kim De Mey](https://github.com/kdeme/) | 1 |
+|	115	| Status | [Konrad Staniec](https://github.com/KonradStaniec/) | 1 |
+|	116	| Status | [Mamy Ratsimbazafy](https://github.com/mratsim/) | 1 |
+|	117	| Status | [Zahary Karadzhov](https://github.com/zah/) | 1 |
+|	118	| Teku | [Adrian Sutton](https://github.com/ajsutton/) | 1 |
+|	119	| Teku | [Ben Edgington](https://github.com/benjaminion/) | 1 |
+|	120	| Teku | [Courtney Hunter](https://github.com/courtneyeh/) | 1 |
+|	121	| Teku | [Dmitry Shmatko](https://github.com/zilm13/) | 1 |
+|	122	| Teku | [Enrico Del Fante](https://github.com/tbenr/) | 1 |
+|	123	| Teku | [Paul Harris](https://github.com/rolfyone/) | 1 |
+|	124	| Teku | [Stefan Bratanov](https://github.com/StefanBratanov/) | 1 |
+|	125	| TXRX | [Alex Vlasov](https://github.com/ericsson49/) | 1 |
+|	126	| TXRX | [Anton Nashatyrev](https://github.com/Nashatyrev/) | 1 |
+|	127	| TXRX | [Mikhail Kalinin](https://github.com/mkalinin/) | 1 |
 
 Temporarily separating out one new member because they are below the 6 month threshold. They can be added in the update next quarter.
 


### PR DESCRIPTION
This PR is to update the membership list with the removed Lodestar contributor as of January 4, 2023.