### PR TITLE
Remove Kaan Uzdogan

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,6 @@ Discussion should be open for ~1 week to give members time to review and contrib
 | 	52	| EF Solidity | [Alex Beregszaszi](https://github.com/axic/) | 1 |
 | 	53	| EF Solidity | [Daniel Kirchner](https://github.com/ekpyron/) | 0.5 |
 | 	54	| EF Solidity | [Harikrishnan Mulackal](https://github.com/hrkrshnn/) | 0.5 |
-| 	55	| EF Solidity | [Kaan Uzdogan](https://github.com/kuzdogan/) | 1 |
 | 	56	| EF Solidity | [Kamil Sliwak](https://github.com/cameel/) | 1 |
 | 	57	| EF Solidity | [Leonardo de Sa Alt](https://github.com/leonardoalt/) | 1 |
 | 	58	| EF Testing | [Mario Vega](https://github.com/marioevz/) | 1 |


### PR DESCRIPTION
As discussed in the Discord channel, [Sourcify](https://sourcify.dev/)'s work does not really fit into PG's scope. Additionally Sourcify has spinned out of the Solidity team with 2023. Previously the team was under Solidity.  