### PR TITLE
Add Lucas Saldanha from teku team

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ Discussion should be open for ~1 week to give members time to review and contrib
  | Teku | [Courtney Hunter](https://github.com/courtneyeh/) | 1 |
  | Teku | [Dmitry Shmatko](https://github.com/zilm13/) | 1 |
  | Teku | [Enrico Del Fante](https://github.com/tbenr/) | 1 |
+ | Teku | [Lucas Saldanha](https://github.com/lucassaldanha) | 1 |
  | Teku | [Paul Harris](https://github.com/rolfyone/) | 1 |
  | Teku | [Stefan Bratanov](https://github.com/StefanBratanov/) | 1 |
  | TXRX | [Alex Vlasov](https://github.com/ericsson49/) | 1 |


### PR DESCRIPTION
Name: Lucas Saldanha
Project: Teku
Discord Handle: Lucas Saldanha#5160

Summary of Work:
Lucas is now working full time as a member of the Teku team, making code changes from August 2022.
He's been working most recently on withdrawals - specifically bls_to_execution changes, and before that was working on sentry node functionality for Teku.

He's been recently working on withdrawals, and will be at the interop.
