### PR TITLE
Add Alexey Osipov from Nethermind

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ Discussion should be open for ~1 week to give members time to review and contrib
  | Lodestar | [Gajinder Singh](https://github.com/g11tech/) | 1 |
  | Lodestar | [Phil Ngo](https://github.com/philknows/) | 1 |
  | Lodestar | [Tuyen Nguyen](https://github.com/tuyennhv/) | 1 |
+ | Nethermind | [Alexey Osipov](https://github.com/flcl42) | 1 |
  | Nethermind | [Daniel Celeda](https://github.com/dceleda/) | 1 |
  | Nethermind | [Jorge Mederos](https://github.com/jmederosalvarado/) | 0.5 |
  | Nethermind | [Łukasz Rozmej](https://github.com/LukaszRozmej/) | 1 |


### PR DESCRIPTION
- Name: Alexey Osipov
- Project: 4844, libp2p in Nethermind
- Team: Nethermind
- Discord handle: FuriKuri#6759
- Link to relevant work: Contributions to Nethermind Ethereum client & c-kzg:  https://github.com/NethermindEth/nethermind/pulls?q=is%3Apr+author%3Aflcl42  https://github.com/ethereum/c-kzg-4844/pulls?q=is%3Apr+author%3Aflcl42
- Summary of their work/eligibility: Alexey started working with the Nethermind team in late May 2022. In the begining he was focusing on general UX improvements and bugfixes. Currently, Alexey is championing 4844 initiative in Nethermind and is the main implementor. Thanks to Alexey contribution Nethermind client is fully working on testnet ( https://notes.ethereum.org/@djrtwo/edelweiss-4844-tracker ) and most of the code is up to prod-ready standards. Post 4844 Alexey will be focusing on leading C# libp2p implementation, which is crucial for Nethermind to participate in further Ethereum protocol development.