### PR TITLE
Update Preston Van Loon from Prysm team to 0.5 weight

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Discussion should be open for ~1 week to give members time to review and contrib
  | Prysmatic | [Kasey Kirkham](https://github.com/kasey/) | 1 |
  | Prysmatic | [Nishant Das](https://github.com/nisdas/) | 1 |
  | Prysmatic | [potuz](https://github.com/potuz/) | 1 |
- | Prysmatic | [Preston Van Loon](https://github.com/prestonvanloon/) | 1 |
+ | Prysmatic | [Preston Van Loon](https://github.com/prestonvanloon/) | 0.5 |
  | Prysmatic | [Radosław Kapka](https://github.com/rkapka/) | 1 |
  | Prysmatic | [Raul Jordan](https://github.com/rauljordan/) | 1 |
  | Prysmatic | [Taran Singh](https://github.com/Taranpreet26311/) | 1 |


### PR DESCRIPTION
Name: @prestonvanloon 
Project: Prysm
Team: Offchain Labs, Previously Prysmatic Labs (acquired)

Rationale:

After joining forces with Offchain Labs, Preston is spending less than full time effort on Ethereum core protocol work. While work on Prysm and Ethereum core development is still the top priority, it is appropriate to reduce the weight to reflect time spent and free up capacity for others to join the guild.
