### PR TITLE
Update Raul Jordan from Prysm team to 0.5 weight

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Discussion should be open for ~1 week to give members time to review and contrib
  | Prysmatic | [potuz](https://github.com/potuz/) | 1 |
  | Prysmatic | [Preston Van Loon](https://github.com/prestonvanloon/) | 1 |
  | Prysmatic | [Radosław Kapka](https://github.com/rkapka/) | 1 |
- | Prysmatic | [Raul Jordan](https://github.com/rauljordan/) | 1 |
+ | Prysmatic | [Raul Jordan](https://github.com/rauljordan/) | 0.5 |
  | Prysmatic | [Taran Singh](https://github.com/Taranpreet26311/) | 1 |
  | Prysmatic | [Terence Tsao](https://github.com/terencechain/) | 1 |
  | Status | [Dustin Brody](https://github.com/tersec/) | 1 |


### PR DESCRIPTION
Name: @rauljordan
Project: Prysm
Team: Offchain Labs, Previously Prysmatic Labs (acquired)

Rationale:

After joining forces with Offchain Labs, Raul is spending less than full time effort on Ethereum core protocol work. While work on Prysm and Ethereum core development is still the top priority, it is appropriate to reduce the weight to reflect time spent and free up capacity for others to join the guild.

