### PR TITLE
Add Andrew Davis from EF DevOps

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Discussion should be open for ~1 week to give members time to review and contrib
 | EF DevOps | [Parithosh Jayanthi](https://github.com/parithosh/) | 1 |
  | EF DevOps | [Rafael Matias](https://github.com/skylenet/) | 0.5 |
  | EF DevOps | [Sam Calder-Mason](https://github.com/samcm/) | 1 |
+ | EF DevOps | [Andrew Davis](https://github.com/savid/) | 1 |
  | EF Geth | [Gary Rong](https://github.com/rjl493456442/) | 1 |
  | EF Geth | [Guillaume Ballet](https://github.com/gballet/) | 1 |
  | EF Geth | [Jared Wasinger](https://github.com/jwasinger/) | 1 |


### PR DESCRIPTION
**Name / Identifier**
Andrew Davis (savid)

**Project**
EF DevOps (EthPandaOps team)

**Link to relevant work**
https://github.com/ethpandaops/xatu
https://github.com/ethpandaops/checkpointz
https://github.com/ethpandaops/ethereum-address-metrics-exporter
https://github.com/ethpandaops/eth-client-docker-image-builder
https://github.com/eth-clients/checkpoint-sync-endpoints
https://github.com/ethpandaops/checkpoint-sync-health-checks

**Summary of their work / eligibility**
Andrew joined the EF DevOps full time August 2022. He initially worked on building out checkpointz in time for the Merge, and then moved on to building out a lot of the infrastructure/tooling that is backing grafana.observability.ethpandaops.io for testnet visibility. 

Over the last few months Andrew has been championing the Big Blocks testing that is happening on Goerli to help determine blob sizes for EIP4844, creating a new project called [xatu](https://github.com/ethpandaops/xatu) in the process. Xatu is running across multiple networks (sepolia, goerli, mainnet) in multiple datacenters to provide observability data, with the general idea that this data is addtionally made available for protocol R&D/incidence response. 

Andrew has been working full time, so I would like to propose him to be added to the Protocol Guild with a weight of 1.