### PR TITLE
Remove Enrique Asapche

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,6 @@ Discussion should be open for ~1 week to give members time to review and contrib
  | Erigon | [Alex Sharov](https://github.com/AskAlexSharov/) | 1 |
  | Erigon | [Andrey Ashikhmin](https://github.com/yperbasis/) | 1 |
  | Erigon | [Artem Vorotnikov](https://github.com/vorot93/) | 0.5 |
- | Erigon | [Enrique Avila Asapche](https://github.com/enriavil1/) | 1 |
  | Erigon | [Giulio Rebuffo](https://github.com/Giulio2002/) | 1 |
  | Erigon | [Michelangelo Riccobene](https://github.com/mriccobene/) | 0.5 |
  | Erigon | [Tullio Canepa](https://github.com/canepat/) | 1 |


### PR DESCRIPTION
Enrique has recently left Erigon and started working at Meta.