### PR TITLE
Remove Proto

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,6 @@ Discussion should be open for ~1 week to give members time to review and contrib
  | EF Research | [Hsiao Wei Wang](https://github.com/hwwhww/) | 1 |
  | EF Research | [Justin Drake](https://github.com/justindrake/) | 1 |
  | EF Research | [Mark Simkin](https://github.com/msimkin.github.io/) | 1 |
- | EF Research | [Proto](https://github.com/protolambda/) | 0.5 |
  | EF Research | [Zhenfei Zhang](https://github.com/zhenfeizhang/) | 0.5 |
  | EF Robust Incentives Group (RIG) | [Anders](https://github.com/anderselowsson/) | 1 |
  | EF Robust Incentives Group (RIG) | [Barnabé Monnot](https://github.com/barnabemonnot/) | 1 |


### PR DESCRIPTION
I decided to leave the Protocol Guild: I am here to contribute to Ethereum, not the guild.

Previously I opted into this to watch & see what happens to this guild initiative: I was afraid it would change the ACD sphere in a negative way by binding together the members. So far that change has been minimal, but I still believe bias of a guild within ACD forms a real risk in Ethereum governance.

Ideologically I also think the guild is starting to look more like a universal basic income thing for core-devs than it rewards impact. It may be great to ensure longevity of Ethereum, but I do not think it will reward the innovation that Ethereum needs to not be out-competed by unaligned L1 projects.

The Guild also attracts two things I believe Ethereum protocol contributors should not be encumbered with:
- A pressure to commercially and pro-actively advertise the guild to DeFi projects for funding. Sure the DeFi projects can fund to signal protocol contribution, but it's better if they decide to do so themselves. And including non-engineering members in the guild to do this exact job makes it even more commercial.
- The guild itself: in the spirit of decentralization, an umbrella around core-devs that pro-actively requests funding for its protocol contributions should not exist. Even if it's minimal & trustless, it's grouping together members in a way that I think creates real significant legal risk.

I hope retro-active funding of independent Ethereum contributor teams based on their past impact, through decision-making by a DAO of external members that includes many more users *on the end-user side*, solves for these problems. And I contribute to Ethereum L1 while also working at OP Labs on the Optimism L2 to support that vision.

Good luck.