### PR TITLE
Add Nazar from Lodestar

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ Discussion should be open for ~1 week to give members time to review and contrib
  | Lodestar | [Cayman Nava](https://github.com/wemeetagain/) | 1 |
  | Lodestar | [dapplion](https://github.com/dapplion/) | 1 |
  | Lodestar | [Gajinder Singh](https://github.com/g11tech/) | 1 |
+ | Lodestar | [Nazar Hussain](https://github.com/nazarhussain/) | 1 |
  | Lodestar | [Phil Ngo](https://github.com/philknows/) | 1 |
  | Lodestar | [Tuyen Nguyen](https://github.com/tuyennhv/) | 1 |
  | Nethermind | [Daniel Celeda](https://github.com/dceleda/) | 1 |


### PR DESCRIPTION
Name / identifier: [Nazar Hussain](https://github.com/nazarhussain)
Team: Lodestar
Link to some work:
- Started with improving some of our [E2E browser testing coverage](https://github.com/ChainSafe/lodestar/pull/4292) back in Aug 2022.
- Continuously improving our [sim tests with other EL clients](https://github.com/ChainSafe/lodestar/pull/4893)
- You’ll likely see him at more Core R&D events including the most recent Edelweiss Interop

Short summary of their work / eligibility:
Nazar joined our team previously developing a good portion of the new web3.js 4.x TypeScript rewrite. He has now moved towards Protocol and has been assisting Lodestar improve its testing infrastructure, improving UX and conformance of our APIs to the spec. 

start date of relevant projects:
Aug 1, 2022

proposed weight (full or partial):
Full