### PR TITLE
Add Mário Havel from Protocol Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Discussion should be open for ~1 week to give members time to review and contrib
  | EF Portal | [Piper Merriam](https://github.com/pipermerriam/) | 1 |
  | EF Privacy & Scaling Explorations (PSE) | [Kevaundray](https://github.com/kevaundray/) | 1 |
  | EF Protocol Support | [Danny Ryan](https://github.com/djrtwo/) | 1 |
+ | EF Protocol Support | [Mário Havel](https://github.com/taxmeifyoucan) | 1 |
  | EF Protocol Support | [Sam Wilson](https://github.com/SamWilsn/) | 1 |
  | EF Protocol Support | [Tim Beiko](https://github.com/timbeiko/) | 1 |
  | EF Protocol Support | [Trenton Van Epps](https://github.com/tvanepps/) | 1 |


### PR DESCRIPTION
Name / identifier: [Mário Havel](https://github.com/taxmeifyoucan)
Team: Protocol Support
Link to some work:

- helps manage the [Ethereum Protocol Fellowship (EPF)](https://blog.ethereum.org/2022/09/01/ethereum-protocol-fellowship-third)
- [Ephemery Testnet](https://notes.ethereum.org/@MarioHavel/testnet-specs) for testing staker setups
- [bordel.wtf](https://bordel.wtf/) TTD visualizer / resource for the Merge
- [eth-rpc-proxy](https://github.com/taxmeifyoucan/eth-rpc-proxy)
- [eipw](https://github.com/ethereum/eipw)
- [Geth preimages db](https://github.com/taxmeifyoucan/preimages)
- [crawler.ethereum.org](https://crawler.ethereum.org/)

Short summary of their work / eligibility:
Mario has been a valuable Protocol Support contributor across projects at a variety of scales. The third EPF cohort has built off previous successes, and continues to show promise as an effective onboarding funnel for new core contributors. For the Merge, he also worked on tooling for ttd predictions on testnets and mainnet, as well as running mining infrastructure for testnets. He has also explored how to run other devops setups, eg. providing endpoints for archive & L2 nodes.

start date of relevant projects:
June 2022

proposed weight (full or partial):
Full