### PR TITLE
Add Pop from EF Research

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,9 +62,10 @@ Discussion should be open for ~1 week to give members time to review and contrib
  | EF Research | [Dmitry Khovratovich](https://github.com/khovratovich/) | 1 |
  | EF Research | [Francesco d’Amato](https://github.com/notes.ethereum.org/@fradamt/) | 1 |
  | EF Research | [George Kadianakis](https://github.com/asn-d6/) | 1 |
- | EF Research | [Hsiao Wei Wang](https://github.com/hwwhww/) | 1 |
+ | EF Research | [Hsiao-Wei Wang](https://github.com/hwwhww/) | 1 |
  | EF Research | [Justin Drake](https://github.com/justindrake/) | 1 |
  | EF Research | [Mark Simkin](https://github.com/msimkin.github.io/) | 1 |
+ | EF Research | [Pop Chunhapanya](https://github.com/ppopth/) | 1 |
  | EF Research | [Zhenfei Zhang](https://github.com/zhenfeizhang/) | 0.5 |
  | EF Robust Incentives Group (RIG) | [Anders](https://github.com/anderselowsson/) | 1 |
  | EF Robust Incentives Group (RIG) | [Barnabé Monnot](https://github.com/barnabemonnot/) | 1 |


### PR DESCRIPTION
Name/identify: Pop Chunhapanya

Team: EF Research

Link to some work:
- https://github.com/ppopth
- https://notes.ethereum.org/@pop
- [Block size of 2MB networking simulation](https://notes.ethereum.org/@pop/2mb-block-size)

Short summary of their work / eligibility: Pop is doing research on the DAS network components and working on a discrete-event network simulation ([ethereum-shadow](https://github.com/ppopth/ethereum-shadow)).

Start date of relevant projects: April, 2022

Proposed weight: full