### PR TITLE
Remove Mamy Ratsimbazafy

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,6 @@ Discussion should be open for ~1 week to give members time to review and contrib
  | Status | [Jacek Sieka](https://github.com/arnetheduck/) | 1 |
  | Status | [Jordan Hrycaj](https://github.com/mjfh/) | 1 |
  | Status | [Kim De Mey](https://github.com/kdeme/) | 1 |
- | Status | [Mamy Ratsimbazafy](https://github.com/mratsim/) | 1 |
  | Status | [Zahary Karadzhov](https://github.com/zah/) | 1 |
  | Teku | [Ben Edgington](https://github.com/benjaminion/) | 1 |
  | Teku | [Courtney Hunter](https://github.com/courtneyeh/) | 1 |


### PR DESCRIPTION
Mamy has decided to pause his contributions to the Nimbus project for the time being, due to personal reasons. His merbership to the protocolguild may be restored in the future.