### PR TITLE
Propose Anton from Lighthouse

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Discussion should be open for ~1 week to give members time to review and contrib
  | Lighthouse | [Paul Hauner](https://github.com/paulhauner/) | 1 |
  | Lighthouse | [Pawan Dhananjay Ravi](https://github.com/pawanjay176/) | 1 |
  | Lighthouse | [Sean Anderson](https://github.com/realbigsean/) | 1 |
- | Lighthouse | [Anton Delaruelle](https://github.com/antondlr) | 0.8 |
+ | Lighthouse | [Anton Delaruelle](https://github.com/antondlr) | 1 |
  | Lodestar | [Afri](https://github.com/q9f/) | 0.5 |
  | Lodestar | [Cayman Nava](https://github.com/wemeetagain/) | 1 |
  | Lodestar | [dapplion](https://github.com/dapplion/) | 1 |


### PR DESCRIPTION
Name/Identifier: [Anton Delaruelle](https://github.com/antondlr)
Team: Lighthouse
Anton's work/eligibility:

Anton has taken up the much needed DevOps position within the Lighthouse team. His work primarily consists of supporting infrastructure for public testnets, running and maintaining public infrastructure (Beacon Watch, Checkpoint sync severs and public Lighthouse APIs), assisting with attacknets, simulations and testing. 

Start Date of relevant projects:
5th September, 2022

Proposed Weight (Full or Partial):
~~Partial: 0.8~~
Full: 1

I originally proposed 0.8 because some of Antons work I consider more Lighthouse-focused an less core-protocol. For example he has recently been working on setting up servers and API endpoints for an up-coming UI we're building in Lighthouse. If the option is between 0.5 and 1 weighting, I think its reasonable Anton falls under the 1 category.
