### PR TITLE
Update Adrian Manning Lighthouse team to 0.5 weight

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Discussion should be open for ~1 week to give members time to review and contrib
  | Hyperledger Besu | [Justin Florentine](https://github.com/jflo/) | 1 |
  | Hyperledger Besu | [Karim Taam](https://github.com/matkt/) | 1 |
  | Independent | [Jim mcDonald](https://github.com/mcdee/) | 0.5 |
- | Lighthouse | [Adrian Manning](https://github.com/AgeManning/) | 1 |
+ | Lighthouse | [Adrian Manning](https://github.com/AgeManning/) | 0.5 |
  | Lighthouse | [Diva Martínez](https://github.com/divagant-martian/) | 1 |
  | Lighthouse | [Mac Ladson](https://github.com/macladson/) | 1 |
  | Lighthouse | [Mark Mackey](https://github.com/ethDreamer/) | 1 |


### PR DESCRIPTION
Name: @AgeManning 
Project: Lighthouse
Team: Sigma Prime

Rationale:

As the Lighthouse team grows as well as the broader ecosystem of the protocol guild, more and more of our time is being consumed on management/oversight rather than core protocol development. We think it's therefore fitting to reduce the weighting in order to benefit new members and contributors to the growing protocol guild ecosystem.