### PR TITLE
Update Mehdi Zerouali Lighthouse team to 0.5 weight

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Discussion should be open for ~1 week to give members time to review and contrib
  | Lighthouse | [Diva Martínez](https://github.com/divagant-martian/) | 1 |
  | Lighthouse | [Mac Ladson](https://github.com/macladson/) | 1 |
  | Lighthouse | [Mark Mackey](https://github.com/ethDreamer/) | 1 |
- | Lighthouse | [Mehdi Zerouali](https://github.com/zedt3ster/) | 1 |
+ | Lighthouse | [Mehdi Zerouali](https://github.com/zedt3ster/) | 0.5 |
  | Lighthouse | [Michael Sproul](https://github.com/michaelsproul/) | 1 |
  | Lighthouse | [Paul Hauner](https://github.com/paulhauner/) | 1 |
  | Lighthouse | [Pawan Dhananjay Ravi](https://github.com/pawanjay176/) | 1 |


### PR DESCRIPTION
Name: @zedt3ster 
Project: Lighthouse
Team: Sigma Prime

Rationale:

As the Lighthouse team grows as well as the broader ecosystem of the protocol guild, more and more of our time is being consumed on management/oversight rather than core protocol development. We think it's therefore fitting to reduce the weighting in order to benefit new members and contributors to the growing protocol guild ecosystem.