### PR TITLE
Add njgheorghita

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Discussion should be open for ~1 week to give members time to review and contrib
  | EF Portal | [Mike Ferris](https://github.com/mrferris/) | 1 |
  | EF Portal | [Ognyan Genev](https://github.com/ogenev/) | 1 |
  | EF Portal | [Piper Merriam](https://github.com/pipermerriam/) | 1 |
+ | EF Portal | [Nick Gheorghita](https://github.com/njgheorghita) | 1 |
  | EF Privacy & Scaling Explorations (PSE) | [Kevaundray](https://github.com/kevaundray/) | 1 |
  | EF Protocol Support | [Danny Ryan](https://github.com/djrtwo/) | 1 |
  | EF Protocol Support | [Guru](https://github.com/gurukamath/) | 0.5 |


### PR DESCRIPTION
Name / identifier: [Nick Gheorghita](https://github.com/njgheorghita) 
Team: Portal Network
Link to some work:
https://github.com/ethereum/trin

@njgheorghita has been a full-time contributor to the Portal Network's Trin implementation for years.

start date of relevant projects:
Early 2021

proposed weight (full or partial):
Full