### PR TITLE
propose Gabriel Fukushima

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ Discussion should be open for ~1 week to give members time to review and contrib
  | Hyperledger Besu | [Danno Ferrin](https://github.com/shemnon/) | 1 |
  | Hyperledger Besu | [Fabio di Fabio](https://github.com/fab-10/) | 1 |
  | Hyperledger Besu | [Gary Schulte](https://github.com/garyschulte/) | 1 |
+ | Hyperledger Besu | [Gabriel Fukushima](https://github.com/gfukushima/) | 1 |
  | Hyperledger Besu | [Jiri Peinlich](https://github.com/gezero/) | 1 |
  | Hyperledger Besu | [Justin Florentine](https://github.com/jflo/) | 1 |
  | Hyperledger Besu | [Karim Taam](https://github.com/matkt/) | 1 |


### PR DESCRIPTION
Name: [Gabriel Fukushima](https://github.com/gfukushima/)
Project: Besu
Discord Handle: gfukushima#2348
### H2 2022: Storage Optimisation, UX improvements and others   
### Ux improvements
 - Jun 2022: Better info on available sync-modes - https://github.com/hyperledger/besu/pull/4017
 - Oct 2022: Log improvemets - https://github.com/hyperledger/besu/pull/4481
 - Nov 2022: Warn ports that are in use when start client - https://github.com/hyperledger/besu/pull/4565
### Storage optimization
 - Oct/Nov/Dec 2022 - Research and spikes (mostly internal ticket management and docs) related to optimising Besu's approach to storage - https://github.com/hyperledger/besu/issues/3693 resulting in:
 - Dec 2022: Experimental feature to checkpoint sync post-merge - https://github.com/hyperledger/besu/pull/4844
### Others
 - Oct 2022: Migration of deprecated feature software from the CLI library used by Besu - https://github.com/hyperledger/besu/pull/4456
### H1 2023: Shanghai development, hive tests maintenance and spec compatibility
### Shanghai development
 - Jan 2023: ForkChoiceUpdate logic fix - https://github.com/hyperledger/besu/pull/4947
 - Jan 2023: JSON RPC Error-32602 (Invalid Params) to return with http status code 200 - https://github.com/hyperledger/besu/pull/4967
 - Feb 2023: First client to implement and pass the getPayloadBodiesByRangeV1 and getPayloadBodiesByHashV1 - https://github.com/hyperledger/besu/pull/4980
 - Feb 2023: Fix for block value calculation - https://github.com/hyperledger/besu/pull/5100
 - Mar 2023: Fix sync bug found after Shanghai upgrade on Sepolia - https://github.com/hyperledger/besu/pull/5174
### Hive tests maintenance
 - Jan 2023: Fix tests failing from withdrawals suite - https://github.com/ethereum/hive/pull/674
 - Jan 2023: Fix Null pointer exception that was broke a lot of hive tests - https://github.com/hyperledger/besu/pull/4954
 - Feb 2023: Fix tests failing from the RPC suite - https://github.com/ethereum/hive/pull/730
### Spec compatibility
 - Jan 2023: eth_feeHistory changed to match spec - https://github.com/hyperledger/besu/pull/5047 