### PR TITLE
Add Felix Lange from the Geth team

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Discussion should be open for ~1 week to give members time to review and contrib
  | EF DevOps | [Andrew Davis](https://github.com/savid/) | 1 |
  | EF Geth | [Gary Rong](https://github.com/rjl493456442/) | 1 |
  | EF Geth | [Guillaume Ballet](https://github.com/gballet/) | 1 |
+ | EF Geth | [Felix Lange](https://github.com/fjl/) | 1 |
  | EF Geth | [Jared Wasinger](https://github.com/jwasinger/) | 1 |
  | EF Geth | [Marius van der Wijden](https://github.com/MariusVanDerWijden/) | 1 |
  | EF Geth | [Martin Holst Swende](https://github.com/holiman/) | 1 |


### PR DESCRIPTION
I would like to propose @fjl

Name / identifier: [Felix Lange](https://github.com/fjl)
Team: Geth
Link to some work:
https://github.com/ethereum/go-ethereum

Felix has been working on the Geth team almost since the creation of EF. He's been the primary designer and developer of [devp2p](https://github.com/ethereum/devp2p) (apart from general Geth work) and the discovery protocols ever since.

start date of relevant projects:
November 2014

proposed weight (full or partial):
Full