### PR TITLE
propose Jason Frame

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ Discussion should be open for ~1 week to give members time to review and contrib
  | Hyperledger Besu | [Fabio di Fabio](https://github.com/fab-10/) | 1 |
  | Hyperledger Besu | [Gary Schulte](https://github.com/garyschulte/) | 1 |
  | Hyperledger Besu | [Gabriel Fukushima](https://github.com/gfukushima/) | 1 |
+ | Hyperledger Besu | [Jason Frame](https://github.com/jframe/) | 1 |
  | Hyperledger Besu | [Jiri Peinlich](https://github.com/gezero/) | 1 |
  | Hyperledger Besu | [Justin Florentine](https://github.com/jflo/) | 1 |
  | Hyperledger Besu | [Karim Taam](https://github.com/matkt/) | 1 |


### PR DESCRIPTION
name: Jason Frame
Project: Besu, Web3Signer
Discord Handle: Jason Frame#3999

### H1 2022: The Merge

- Feb 2022: Web3Signer research and investigation on changes needed for the merge https://github.com/ConsenSys/web3signer/issues/459
- May 2022: Web3Signer Ropsten support and testing https://github.com/ConsenSys/web3signer/issues/579

### H2 2022: Storage optimisation, Shanghai
- Jul-Dec 2022: Research and prototyping on approaches for reducing Besu's storage https://github.com/hyperledger/besu/issues/3693
- Jul 2022: Spike external DB https://github.com/jframe/besu/tree/spike_external_db
- Oct 2022: Spike Bonsai storage with trie branches using flat storage exclusively https://github.com/hyperledger/besu/pull/4514
- Nov 2022: Storage block pruning prototype https://github.com/jframe/besu/tree/rocksdb_chain_pruning

### H2 2022: Shanghai
- Dec 2022: Co-contributor to 4895 spike https://github.com/gezero/besu/commits/eip-4895-withdrawals
- Dec 2022: EIP-6122 Timestamp based fork IDs https://github.com/hyperledger/besu/pull/4841

### H1 2023: Shanghai
- Jan 2023: Withdrawals type https://github.com/hyperledger/besu/pull/4892
- Jan 2023: Withdrawals processing https://github.com/hyperledger/besu/pull/4917
- Jan 2023: Withdrawals root https://github.com/hyperledger/besu/pull/4962
- Jan 2023: Withdrawals wiring https://github.com/hyperledger/besu/pull/4968
- Jan-Feb 2023: Reference test fixes https://github.com/hyperledger/besu/pull/5057 & https://github.com/hyperledger/besu/pull/5019
- Mar 2023: Withdrawals acceptance tests https://github.com/hyperledger/besu/pull/5141
- Jan-Mar 2023: Other various withdrawals and Shanghai commits https://github.com/hyperledger/besu/commits?author=jframe&since=2023-01-01