### PR TITLE
Add Kamil Chodoła from Nethermind

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,12 +134,13 @@ Discussion should be open for ~1 week to give members time to review and contrib
  | Nethermind | [Alexey Osipov](https://github.com/flcl42) | 1 |
  | Nethermind | [Daniel Celeda](https://github.com/dceleda/) | 1 |
  | Nethermind | [Jorge Mederos](https://github.com/jmederosalvarado/) | 0.5 |
+ | Nethermind | [Kamil Chodoła](https://github.com/kamilchodola/) | 1 |
  | Nethermind | [Łukasz Rozmej](https://github.com/LukaszRozmej/) | 1 |
  | Nethermind | [Marcin Sobczak](https://github.com/marcindsobczak/) | 1 |
  | Nethermind | [Marek Moraczyński](https://github.com/MarekM25/) | 1 |
  | Nethermind | [Mateusz Jędrzejewski](https://github.com/matilote/) | 0.5 |
- | Nethermind | [Tanishq](https://github.com/tanishqjasoria/) | 1 |
- | Nethermind | [Tomasz Stanzeck](https://github.com/tkstanczak/) | 0.5 |
+ | Nethermind | [Tanishq Jasoria](https://github.com/tanishqjasoria/) | 1 |
+ | Nethermind | [Tomasz Stanczak](https://github.com/tkstanczak/) | 0.5 |
  | Prysmatic | [James He](https://github.com/james-prysm/) | 1 |
  | Prysmatic | [Kasey Kirkham](https://github.com/kasey/) | 1 |
  | Prysmatic | [Nishant Das](https://github.com/nisdas/) | 1 |


### PR DESCRIPTION
* Project: Nethermind Client QA Lead
* Team: Nethermind
* Joined: 17/08/2022
* Discord handle: kamil_chodola#5979
* Summary of their work/eligibility: Kamil started working in Nethermind before the Merge. He is leading our QA efforts and his contribution directly corresponds to Nethermind increased stability and market share. Kamil is also our unofficial release manager, helping with coordinating releases, doing release testing and signing off the release. Also coordinating efforts in user support to improve User Experience, help users run Nethermind seamlessly and push towards UX improvements in client according to users needs.
Link to relevant work: Contributions to Nethermind Ethereum and tools which are heavily used in testing phase of client. https://github.com/NethermindEth/nethermind/pulls?q=is%3Apr+author%3Akamilchodola , https://github.com/NethermindEth/nethermind-node-tests/pulls?q=is%3Apr+author%3Akamilchodola+ , https://github.com/NethermindEth/post-merge-smoke-tests/pulls?q=is%3Apr+author%3Akamilchodola+