### PR TITLE
Add Ahmad Bitar from Nethermind with 0.5 weight

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ Discussion should be open for ~1 week to give members time to review and contrib
  | Lodestar | [Nazar Hussain](https://github.com/nazarhussain/) | 1 |
  | Lodestar | [Phil Ngo](https://github.com/philknows/) | 1 |
  | Lodestar | [Tuyen Nguyen](https://github.com/tuyennhv/) | 1 |
+ | Nethermind | [Ahmad Bitar](https://github.com/smartprogrammer93 ) | 0.5 |
  | Nethermind | [Alexey Osipov](https://github.com/flcl42) | 1 |
  | Nethermind | [Daniel Celeda](https://github.com/dceleda/) | 1 |
  | Nethermind | [Jorge Mederos](https://github.com/jmederosalvarado/) | 0.5 |


### PR DESCRIPTION
Name: Ahmad Bitar
Project: EOF, timestamp forking, Modularization
Weight: 0.5 (Ahmad currently also helps with other projects in Nethermind)
Team: Nethermind
Discord handle: smartprogrammer#7532
Link to relevant work: https://github.com/NethermindEth/nethermind/pulls?q=is%3Apr+author%3Asmartprogrammer93
Summary of their work/eligibility: Ahmad Bitar has been a contributor to the Nethermind client since August 2022. He was responsible for implementing timestamp-based forking and fork ID changes for Shanghai. Ahmad has also implemented EIP-3651 for Shanghai and EIP-6780 for Cancun. He has collaborated on EOF discussions and development. Post these projects, Ahmad is expected to continue implementing EIPs and modularizing the client.