### PR TITLE
Add Henri Dubois-Ferriere (Independent)

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ Discussion should be open for ~1 week to give members time to review and contrib
  | Hyperledger Besu | [Justin Florentine](https://github.com/jflo/) | 1 |
  | Hyperledger Besu | [Karim Taam](https://github.com/matkt/) | 1 |
  | Hyperledger Besu | [Simon Dudley](https://github.com/siladu/) | 1 |
+ | Independent | [Henri Dubois-Ferriere](https://github.com/henridf/) | 1 |
  | Independent | [Jim mcDonald](https://github.com/mcdee/) | 0.5 |
  | Lighthouse | [Adrian Manning](https://github.com/AgeManning/) | 0.5 |
  | Lighthouse | [Diva Martínez](https://github.com/divagant-martian/) | 1 |


### PR DESCRIPTION
Name: [Henri Dubois-Ferriere](https://github.com/henridf/)
Team: Independent (Funded through EF)
Discord: henridf#9772

Main contributions:

- EIP-4444 (Apr 2022 – Oct 2022)
  - Prototyping/Exploration: https://github.com/ethereum/go-ethereum/pull/25325
- EIP-4844 (Nov 2022 – Ongoing)
  - Nimbus implementation: https://github.com/status-im/nimbus-eth2/pulls?q=is%3Apr+author%3Ahenridf+is%3Aclosed 
    - https://github.com/status-im/nimbus-eth2/pull/4808
    - https://github.com/status-im/nimbus-eth2/pull/4844
  - Edelweiss interop
- Specs
  - https://github.com/ethereum/consensus-specs/pull/3269