### PR TITLE
add cheeky-gorilla 

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ Discussion should be open for ~1 week to give members time to review and contrib
  | Hyperledger Besu | [Justin Florentine](https://github.com/jflo/) | 1 |
  | Hyperledger Besu | [Karim Taam](https://github.com/matkt/) | 1 |
  | Hyperledger Besu | [Simon Dudley](https://github.com/siladu/) | 1 |
+ | Independent | [Cheeky-gorilla](https://github.com/cheeky-gorilla) | 1 |
  | Independent | [Jim mcDonald](https://github.com/mcdee/) | 0.5 |
  | Lighthouse | [Adrian Manning](https://github.com/AgeManning/) | 0.5 |
  | Lighthouse | [Diva Martínez](https://github.com/divagant-martian/) | 1 |


### PR DESCRIPTION
name: cheeky-gorilla
Project: Independent
Discord Handle: cheeky-gorilla#6168
Start date: Oct 15 2022
Proposed Weight: Full

Cheeky-gorilla has been an amazing Guild contributor since Devcon Bogota. I believe he should be eligible for the funding that membership entails due to his work building the Guild itself. This is outside of the existing eligibility requirements for members, and would require minor changes to the Guild eligibility as described today in the docs: [please review here](https://github.com/protocolguild/docs/pull/42).

Here’s some context for why I think eligibility should be broadened to allow his full membership:

- Growing/stewarding/maintaining PG requires real effort. While this work is significantly lower than other entities (eg. offchain grants org, onchain DAOs which vote on proposals), it’s still more than current members may want to commit to. Cheeky has slotted very well into this work and proven his value many times over (examples below)
- While the Guild didn’t start with this type of membership, I have a strong conviction that this type of contributor will be crucial to scaling the mechanism to new levels: both in evolving the org and engaging in fundraising. Especially in these early days, I think it’s important that the collective remain adaptive enough to respond to its environment or changing needs.
- Just as with other nominations, we should maintain a very high bar for this type of role. I do not expect this contributor to be a significant share of the membership over time.
- Proposing as a full member instead of a salaried/capped contributor makes sense for two reasons 1. Using our existing weighting is the simplest option, both in terms of decision-making and not needing to modify the onchain flow of funding. This is in keeping with the Guild’s bias towards simplicity: using existing off-the shelf contracts when possible, minimizing governance overhead, foreclosing subjective decision-making. 2. Full membership for this type of role is more incentive compatible: members with upside exposure are incentivized to raise funding to increase their total benefit from high quality funding sources. A capped compensation does not provide the same level of skin in the game. 

Here’s an overview of the incredible work he’s been involved with so far:

📜 [Mid-Pilot update](https://protocol-guild.readthedocs.io/en/latest/5-initial-pilot.html#mid-pilot-update-dec-7-2022) - Wrote this entire report with review and edits from me. Being introspective and documenting our progress is an important component of any org

🤖  Smart contract architecture / PG v2 - organizing regular calls with DAOHaus & 0xSplits to iterate on the registry contract and UI to interact with it, a key component of a fully onchain PG. has helped explore L2 integrations. wrote up explainers for members to reference at Austria, takes detailed notes of every meeting.

💰 Fundraising - has been engaged strongly on this front: sourcing leads, keeping conversations warm, explaining the concept of PG and advocating for its usefulness to potential funders

🧑‍⚖️ Legal entity working group - engaged since Austria, taking detailed notes

⚖️ [Decision-making framework](https://docs.google.com/document/d/1a4RG_aqgBSi2ItiiPeD5a-5SI7d0O-ddZyrAsqn2QRI/edit?usp=sharing) - wrote up a potential decision making framework that would work with the new onchain architecture, as well as example proposals

📣 Comms/social media - created a shared calendar of important PG milestones to share with the broader community. creates tweets to send. created google group. building PG 1% norms is inherently a social effort, having more hands to help here is crucial.

🧑‍🏫 Presentations - helped with ETHDenver slide prep, presented at Zuzalu, participated in discussions there. He is also applying to other ETH events in europe to present PG when Tim and I cant travel.

📈 Transparency: Is working on a revamp of the [Dune dashboard](https://dune.com/datamonkey_eth/protocol-guild)