### PR TITLE
Propose Gabriel Trintinalia

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ Discussion should be open for ~1 week to give members time to review and contrib
  | Hyperledger Besu | [Fabio di Fabio](https://github.com/fab-10/) | 1 |
  | Hyperledger Besu | [Gary Schulte](https://github.com/garyschulte/) | 1 |
  | Hyperledger Besu | [Gabriel Fukushima](https://github.com/gfukushima/) | 1 |
+ | Hyperledger Besu | [Gabriel Trintinalia](https://github.com/Gabriel-Trintinalia/) | 1 |
  | Hyperledger Besu | [Jason Frame](https://github.com/jframe/) | 1 |
  | Hyperledger Besu | [Jiri Peinlich](https://github.com/gezero/) | 1 |
  | Hyperledger Besu | [Justin Florentine](https://github.com/jflo/) | 1 |


### PR DESCRIPTION
* Name: Gabriel Trintinalia
* Project: Besu
* Discord Handle: gabrieltrintinalia#5694
* Proposed Weight: full
* Start Date: June 28th 2022
* Short summary of their work / eligibility: 
  * PRs: https://github.com/hyperledger/besu/pulls?q=is%3Apr+author%3AGabriel-Trintinalia+is%3Aclosed+label%3Amainnet
  * Reviews: https://github.com/hyperledger/besu/pulls?q=is%3Apr+reviewed-by%3AGabriel-Trintinalia+label%3Amainnet+

Gabriel has worked on Besu mainnet since end of June 2022, with a gap for another project starting in March 2023, so total 7 months. 
The majority of this work has been peering and RPC improvements, as well as some Shanghai work.
In about a month, Gabriel will be picking up Cancun work and continuing on core mainnet development.