### PR TITLE
Propose Sally MacFarlane

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ Discussion should be open for ~1 week to give members time to review and contrib
  | Hyperledger Besu | [Jiri Peinlich](https://github.com/gezero/) | 1 |
  | Hyperledger Besu | [Justin Florentine](https://github.com/jflo/) | 1 |
  | Hyperledger Besu | [Karim Taam](https://github.com/matkt/) | 1 |
+ | Hyperledger Besu | [Sally Macfarlane](https://github.com/macfarla/) | 1 |
  | Hyperledger Besu | [Simon Dudley](https://github.com/siladu/) | 1 |
  | Independent | [Jim mcDonald](https://github.com/mcdee/) | 0.5 |
  | Lighthouse | [Adrian Manning](https://github.com/AgeManning/) | 0.5 |


### PR DESCRIPTION
* Name: Sally MacFarlane
* Project: Besu
* Discord Handle: macfarla | Besu#9315
* Proposed Weight: full
* Start Date: 
  * Half time: Jan 28th 2022
  * Full time: May 5th 2022
* Short summary of their work / eligibility: 
  * PRs
https://github.com/hyperledger/besu/pulls?q=is%3Apr+author%3Amacfarla+label%3Amainnet+
  * Reviews
https://github.com/hyperledger/besu/pulls?q=is%3Apr+reviewed-by%3Amacfarla+label%3Amainnet+

Sally has worked ~50% on Besu mainnet since January 2022 and majority of time since May 2022, with a gap for another project starting in March 2023, so total full time of 8 months. 
In about a month, Sally will be picking up Cancun work and continuing on core mainnet development.

Sally's eligible work consists Trace API, peering improvements and a wide range of Besu maintenance. Also line management of other core developers.