### PR TITLE
Add Radosław Zagórowicz from EF Ipsilon

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Discussion should be open for ~1 week to give members time to review and contrib
  | EF Ipsilon | [Andrei Maiboroda](https://github.com/gumb0/) | 1 |
  | EF Ipsilon | [Jose Hugo de la cruz Romero](https://github.com/hugo-dc/) | 0.5 |
  | EF Ipsilon | [Paweł Bylica](https://github.com/chfast/) | 1 |
+ | EF Ipsilon | [Radosław Zagórowicz](https://github.com/rodiazet) | 1 |
  | EF JavaScript | [Andrew Day](https://github.com/acolytec3/) | 1 |
  | EF JavaScript | [Gabriel](https://github.com/gabrocheleau/) | 0.5 |
  | EF JavaScript | [Holger Drewes](https://github.com/holgerd77/) | 0.5 |


### PR DESCRIPTION
* Name: Radosław Zagórowicz
* Project: EF Ipsilon
* Discord Handle: rodiazet#9044
* Proposed Weight: full
* Start Date: November 2022
* Short summary of their work / eligibility:
        PRs
        https://github.com/ethereum/evmone/pulls?q=is%3Apr+author%3Arodiazet
        Reviews
        https://github.com/ethereum/evmone/pulls?q=reviewed-by%3Arodiazet

Radosław has been working full time on evmone project including big portion of EVM Object Format implementation and enhancing EVM testing tools.

