### PR TITLE
Add Luca Zanolini from EF Research team

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ Discussion should be open for ~1 week to give members time to review and contrib
  | EF Research | [George Kadianakis](https://github.com/asn-d6/) | 1 |
  | EF Research | [Hsiao-Wei Wang](https://github.com/hwwhww/) | 1 |
  | EF Research | [Justin Drake](https://github.com/justindrake/) | 1 |
+ | EF Research | [Luca Zanolini](https://github.com/LucaZanolini) | 1 |
  | EF Research | [Mark Simkin](https://github.com/msimkin.github.io/) | 1 |
  | EF Research | [Pop Chunhapanya](https://github.com/ppopth/) | 1 |
  | EF Research | [Zhenfei Zhang](https://github.com/zhenfeizhang/) | 0.5 |


### PR DESCRIPTION
- Name: Luca Zanolini
- Team: EF Research
- Link to past work:
  - [A Simple Single Slot Finality Protocol For Ethereum](https://arxiv.org/abs/2302.12745)
  - [Confirmation Rule for Ethereum PoS](https://ethresear.ch/t/confirmation-rule-for-ethereum-pos/15454)
  - [Recent Latest Message Driven GHOST: Balancing Dynamic Availability With Asynchrony Resilience](https://arxiv.org/abs/2302.11326)
  - [Evolution of the Ethereum Proof-of-Stake Consensus Protocol](https://github.com/ethereum/pos-evolution) 

- Short summary of their work / Eligibility: 
  - Luca works on consensus protocol research in the EF Research team.
  - He joined the team in a part time capacity in October 2022, and in full-time capacity in January 2023.
- Start date of relevant projects: January 2023 (this was when Luca started working full-time in EF Research)
- Proposed weight: 1