### PR TITLE
(Re) Propose Henri DF

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ Discussion should be open for ~1 week to give members time to review and contrib
  | Hyperledger Besu | [Karim Taam](https://github.com/matkt/) | 1 |
  | Hyperledger Besu | [Simon Dudley](https://github.com/siladu/) | 1 |
  | Independent | [Jim mcDonald](https://github.com/mcdee/) | 0.5 |
+ | Independent | [Henri Dubois-Ferriere](https://github.com/henridf/) | 1 |
  | Lighthouse | [Adrian Manning](https://github.com/AgeManning/) | 0.5 |
  | Lighthouse | [Diva Martínez](https://github.com/divagant-martian/) | 1 |
  | Lighthouse | [Mac Ladson](https://github.com/macladson/) | 1 |


### PR DESCRIPTION
After some [back](https://github.com/protocolguild/membership/pull/63) and [forth](https://github.com/protocolguild/membership/pull/68), and some discussions with Henri, he shared that he'd like to be considered for PG based on his current 4844 work for Nimbus. 

Although the work is bounded in scope (i.e. his grant from the EF to work with Nimbus will cease after 4844 is done being implemented), Henri mentioned he'd like to keep working on L1 core work afterwards. He isn't sure exactly _what_ he will be working on, but would like to stick around. 

If he doesn't, then he'd be fine being removed from PG. But, given he meets the criteria of >6 months of core L1 work, it makes sense to include him. See https://github.com/protocolguild/membership/pull/63 for a list of his contributions. 