### PR TITLE
add Sina Mahmoodi as a member

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Discussion should be open for ~1 week to give members time to review and contrib
  | EF Geth | [Martin Holst Swende](https://github.com/holiman/) | 1 |
  | EF Geth | [Matt Garnett](https://github.com/lightclient/) | 1 |
  | EF Geth | [Peter Szilagyi](https://github.com/karalabe/) | 1 |
+ | EF Geth | [Sina Mahmoodi](https://github.com/s1na/) | 1 |
  | EF Ipsilon | [Alex Beregszaszi](https://github.com/axic/) | 1 |
  | EF Ipsilon | [Andrei Maiboroda](https://github.com/gumb0/) | 1 |
  | EF Ipsilon | [Jose Hugo de la cruz Romero](https://github.com/hugo-dc/) | 0.5 |


### PR DESCRIPTION
Name / identifier : Sina Mahmoodi / s1na
Team : Geth
Link to some work : https://github.com/ethereum/go-ethereum/pull/23708 https://github.com/ethereum/go-ethereum/pull/23773 https://medium.com/ewasm/evm-bytecode-merklization-2a8366ab0c90 
Short summary of their work / eligibility : Sina has been a full-fledged contributor to the Ethereum project. He contributed to ethereumjs, ewasm and geth. Recently, he has focused on improving the usability of the geth client by working on hive, the graphql API, tracing and event filtering.
start date of relevant projects : 01/19
proposed weight (full or partial) : full
