### PR TITLE
remove solidity contributors

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,9 +91,6 @@ Discussion should be open for ~1 week to give members time to review and contrib
  | EF Security | [Justin Traglia](https://github.com/jtraglia/) | 1 |
  | EF Security | [Tyler Holmes](https://github.com/z3n-chada/) | 1 |
  | EF Security | [Yoav Weiss](https://github.com/yoavw/) | 1 |
- | EF Solidity | [Daniel Kirchner](https://github.com/ekpyron/) | 0.5 |
- | EF Solidity | [Harikrishnan Mulackal](https://github.com/hrkrshnn/) | 0.5 |
- | EF Solidity | [Kamil Sliwak](https://github.com/cameel/) | 1 |
  | EF Testing | [Mario Vega](https://github.com/marioevz/) | 1 |
  | Erigon | [Alex Sharov](https://github.com/AskAlexSharov/) | 1 |
  | Erigon | [Andrey Ashikhmin](https://github.com/yperbasis/) | 1 |


### PR DESCRIPTION
We are now at the end of the 12 month Pilot. As such, we should close the loop on some previous discussions related to member eligibility and Solidity:

- [Github: Protocol Guild Eligibility for dev tooling post-Pilot](https://github.com/protocolguild/membership/issues/18)
- [Github: Add Daniel Kirchner](https://github.com/protocolguild/membership/pull/17)
- [Discord mention from Axic](https://discordapp.com/channels/795514951376568391/912091925077688330/933827459403636837)
- [Discord mention from Axic 2](https://discordapp.com/channels/795514951376568391/912091925077688330/923726142425415721)
- [Discord discussion from James, Acolytec3, Trent](https://discord.com/channels/795514951376568391/912091925077688330/940358706628030464)

The first Github link has the most substantive discussion. In summary, our membership should be consistent with how our own documentation describes eligibility: strictly related to the core protocol and its ongoing stewardship. While smart contract languages are important for the long term success of Ethereum / the EVM, they are not part of the core protocol. Solidity is the only smart contract language with PG members; not Vyper, Fe, Huff, etc. Further, this also doesn’t consider other crucial adjacent developer tooling, like dev environments and libraries.

Maintaining this discrepancy past the end of the Pilot will reduce the credibility of the Guild’s claims regarding accurate curation according to our own self-defined internal processes.

This PR removes three existing Solidity contributors: @ekpyron @hrkrshnn @cameel. I have reached out in advance and communicated this to them. This has nothing to do with these individuals or their work, and I personally appreciate their participation in the PG experiment over the last ~12 months.

To be clear - this isn't a unilateral decision being handed down, I'm posting this proposal as an individual member. If there are holes in my reasoning, please give me pushback!

_As an aside - In my personal capacity, I fully support dev tooling contributors exploring a PG analogue for their domain, and happy to provide guidance if needed._