### PR TITLE
Remove 0xSplits

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,6 @@ Discussion should be open for ~1 week to give members time to review and contrib
 
 | Team  |                Name / Link to work |  Multiplier |
 | :---        |        :--- |        :--- |
-| 0xSplits | [donations.0xSplits.eth](https://github.com/0xSplits/) | 1 |
 | EF DevOps | [Parithosh Jayanthi](https://github.com/parithosh/) | 1 |
  | EF DevOps | [Rafael Matias](https://github.com/skylenet/) | 0.5 |
  | EF DevOps | [Sam Calder-Mason](https://github.com/samcm/) | 1 |


### PR DESCRIPTION
At the beginning of the Pilot we included the 0xSplits donation address as thanks for their work developing the vesting contract pro-bono.

Now that the Pilot has concluded, it makes sense to remove them as a long-term beneficiary. I don't think we need to wait a week for discussion (it's not a typical membership addition/removal) so I will merge directly.