### PR TITLE
Add Nico Flaig (Lodestar)

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ Discussion should be open for ~1 week to give members time to review and contrib
  | Lodestar | [dapplion](https://github.com/dapplion/) | 1 |
  | Lodestar | [Gajinder Singh](https://github.com/g11tech/) | 1 |
  | Lodestar | [Nazar Hussain](https://github.com/nazarhussain/) | 1 |
+ | Lodestar | [Nico Flaig](https://github.com/nflaig) | 1 |
  | Lodestar | [Phil Ngo](https://github.com/philknows/) | 1 |
  | Lodestar | [Tuyen Nguyen](https://github.com/tuyennhv/) | 1 |
  | Nethermind | [Ahmad Bitar](https://github.com/smartprogrammer93 ) | 0.5 |


### PR DESCRIPTION
Name / identifier: [Nico Flaig](https://github.com/nflaig)
Team: Lodestar
Discord: nflaig#9284
Proposed Weight: Full
Start Date: Nov 2022

Short summary of their work / eligibility:
Nico is a new member of Lodestar contributing part-time since Nov 2022, full-time starting March 2023 when he met us at Devcon 6. His work aligns mostly with helping Lodestar improve as a client. Most of the maintenance work has allowed us to improve performance our client, conform to specs & further integrate Lodestar into community initiatives, contributing to client diversity. This includes pushing our integrations into Rocketpool, DappNode, Eth-Docker, beaconcha.in metrics and experimental implementations such as Obol DVT, being the first client to implement attestation aggregation in a distributed cluster. 

Link to some notable work:
https://github.com/ChainSafe/lodestar/pull/5454
https://github.com/ChainSafe/lodestar/pull/5330
https://github.com/ChainSafe/lodestar/pull/5037
https://github.com/ChainSafe/lodestar/pull/5344
https://github.com/ChainSafe/lodestar/pull/5109

All submitted PRs to the Lodestar monorepo:
https://github.com/ChainSafe/lodestar/pulls?page=1&q=is%3Apr+is%3Aclosed+author%3Anflaig