### PR TITLE
Remove @divma (myself) from PG

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,6 @@ Discussion should be open for ~1 week to give members time to review and contrib
  | Independent | [Jim mcDonald](https://github.com/mcdee/) | 0.5 |
  | Independent | [Henri Dubois-Ferriere](https://github.com/henridf/) | 1 |
  | Lighthouse | [Adrian Manning](https://github.com/AgeManning/) | 0.5 |
- | Lighthouse | [Diva Martínez](https://github.com/divagant-martian/) | 1 |
  | Lighthouse | [Mac Ladson](https://github.com/macladson/) | 1 |
  | Lighthouse | [Mark Mackey](https://github.com/ethDreamer/) | 1 |
  | Lighthouse | [Mehdi Zerouali](https://github.com/zedt3ster/) | 0.5 |


### PR DESCRIPTION
I've left Sigma prime after more than 3 years of awesome network related development. 

While I intend to continue to contribute, and have done it since I left the company - around 3 weeks ago - I can't in good conscience claim I'll be able to contribute the equivalent of a half time job. My plan is to contribute around 10 hours a week. Why do I know that? well I need time management. I'm not really going anywhere, but I'm sadly no longer eligible for PG under a scheme where only `0.5` and `1` are acceptable.

Wish everyone the best