### PR TITLE
Add @jsign to the PG membership

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ Discussion should be open for ~1 week to give members time to review and contrib
  | EF Security | [Justin Traglia](https://github.com/jtraglia/) | 1 |
  | EF Security | [Tyler Holmes](https://github.com/z3n-chada/) | 1 |
  | EF Security | [Yoav Weiss](https://github.com/yoavw/) | 1 |
+ | EF Stateless Consensus| [Ignacio Hagopian](https://github.com/jsign/) | 1 |
  | EF Testing | [Mario Vega](https://github.com/marioevz/) | 1 |
  | Erigon | [Alex Sharov](https://github.com/AskAlexSharov/) | 1 |
  | Erigon | [Andrey Ashikhmin](https://github.com/yperbasis/) | 1 |


### PR DESCRIPTION
Name / identifier: Ignacio Hagopian / jsign
Team: Stateless Consensus (EF)

Short summary of their work / eligibility: Ignacio has been working on stateless Ethereum, first as an EPF member and then as a member of the Stateless Consensus team at the EF. He has helped with the development effort on the verkle trees and the verkle tree transition in particular, greatly improving the performance of both. Outside of his main gig, Ignacio has also a strong interest in cryptography and has helped other research efforts, like the trusted ceremony setup or whisk.

Link to some work:

 - https://github.com/gballet/go-verkle/pull/370, https://github.com/gballet/go-verkle/pull/369 and https://github.com/gballet/go-ethereum/pull/196, samples of the PRs that Ignacio created and had an impact on the speed of block execution for verkle trees.
 - https://hackmd.io/@jsign/vkt-proofs-implementation-notes some notes on the verkle tree implementation
 - https://github.com/jsign/go-kzg-ceremony-client a kzg ceremony client
 - https://github.com/jsign/go-curdleproofs a curdleproof implementation

start date of relevant projects: October 22

proposed weight (full or partial): full
