### PR TITLE
Propose Navie Chan

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ Discussion should be open for ~1 week to give members time to review and contrib
  | Independent | [Cheeky-gorilla](https://github.com/cheeky-gorilla) | 1 |
  | Independent | [Jim mcDonald](https://github.com/mcdee/) | 0.5 |
  | Independent | [Henri Dubois-Ferriere](https://github.com/henridf/) | 1 |
+ | Independent | [Navie Chan](https://github.com/naviechan/) | 0.5 |
  | Lighthouse | [Adrian Manning](https://github.com/AgeManning/) | 0.5 |
  | Lighthouse | [Mac Ladson](https://github.com/macladson/) | 1 |
  | Lighthouse | [Mark Mackey](https://github.com/ethDreamer/) | 1 |


### PR DESCRIPTION
Name: Navie Chan
Team: Independent Contributor
Discord Handle: NC#0558
Weight: partial, junior

## Oct 2022 - Feb 2023: EPF
* Consensus client reward APIs [overview](https://github.com/kevinbogner/cohort-three/blob/master/projects/consensus_client_reward_APIs.md)
	* block_rewards and attestation_rewards in Lighthouse [#3907](https://github.com/sigp/lighthouse/pull/3907)
	* sync_committee_rewards in Lighthouse [#3903](https://github.com/sigp/lighthouse/pull/3903)

## Feb 2023: Reth
* Adding test support for several API module to Reth [#1288](https://github.com/paradigmxyz/reth/pull/1288)

## Mar 2023 - Jul 2023: EIP-6110 prototype
* Besu implementation [#5295](https://github.com/hyperledger/besu/pull/5295), [#5055](https://github.com/hyperledger/besu/pull/5055)
* [EIP-6110 PEEPanEIP](https://www.youtube.com/watch?v=tRTBgCN9VgY)

## May 2023: Erigon
* Diagnositc and debugging endpoints [#7417](https://github.com/ledgerwatch/erigon/pull/7417), [#10](https://github.com/ledgerwatch/diagnostics/pull/10)

## Next plans
* Fixing some Hive tests for Besu
* Getting involved in ePBS implementation in Lodestar during at least next 3 months
