### PR TITLE
Add Ayman Bouchareb

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ Discussion should be open for ~1 week to give members time to review and contrib
  | Lodestar | [Tuyen Nguyen](https://github.com/tuyennhv/) | 1 |
  | Nethermind | [Ahmad Bitar](https://github.com/smartprogrammer93 ) | 0.5 |
  | Nethermind | [Alexey Osipov](https://github.com/flcl42) | 1 |
+ | Nethermind | [Ayman Bouchareb](https://github.com/Demuirgos) | 1 |
  | Nethermind | [Daniel Celeda](https://github.com/dceleda/) | 1 |
  | Nethermind | [Jorge Mederos](https://github.com/jmederosalvarado/) | 0.5 |
  | Nethermind | [Kamil Chodoła](https://github.com/kamilchodola/) | 1 |


### PR DESCRIPTION
- Name: Ayman Bouchareb
- Project: Eof, Eip5656, Eip4788
- Team: Nethermind
- Discord handle: code_talker_23
- Link to relevant work: Contributions to Nethermind Ethereum client & https://github.com/NethermindEth/nethermind/pulls?q=is%3Apr+author%3ADemuirgos
- Summary of their work/eligibility: Ayman started working with the Nethermind team in late July 2022. At the start, he was focusing on general improvements and bug fixes. Currently, Ayman is championing EOF initiative in Nethermind and is the main implementor. He is also implementing various other EIPs such as EIP 4788 and EIP 5656 which are crucial for Nethermind to be Cancun ready.