### PR TITLE
Add Spencer Taylor-Brown

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ Discussion should be open for ~1 week to give members time to review and contrib
  | EF Security | [Yoav Weiss](https://github.com/yoavw/) | 1 |
  | EF Stateless Consensus| [Ignacio Hagopian](https://github.com/jsign/) | 1 |
  | EF Testing | [Mario Vega](https://github.com/marioevz/) | 1 |
+ | EF Testing | [Spencer Taylor-Brown](https://github.com/spencer-tb/) | 1 |
  | Erigon | [Alex Sharov](https://github.com/AskAlexSharov/) | 1 |
  | Erigon | [Andrey Ashikhmin](https://github.com/yperbasis/) | 1 |
  | Erigon | [Artem Vorotnikov](https://github.com/vorot93/) | 0.5 |


### PR DESCRIPTION
# Name
Spencer Taylor-Brown

# Team
Testing Team @ Ethereum Foundation

# Link to some work

## Code

- Active maintainer of [execution-spec-tests](https://github.com/ethereum/execution-spec-tests): that generates test fixtures for execution clients to run.
- [Pyspec Hive Simulator](https://github.com/ethereum/hive/tree/master/simulators/ethereum/pyspec): Runs the execution client tests using the Engine API.
- Some EIP-4844 related work:
    - [DataGasUsed Genesis BlockHeader Workaround](https://github.com/ethereum/execution-spec-tests/pull/145/files).
    - [Blobhash Opcode Tests](https://github.com/ethereum/execution-spec-tests/blob/main/tests/cancun/eip4844_blobs/test_blobhash_opcode.py).

## Talks

- Co-presenting execution-spec-tests in ACD [execution layer meeting 164](https://www.youtube.com/live/09Kzi2x06UM?feature=share&t=475).

## In progress

- [EIP-4788 Tests](https://github.com/ethereum/execution-spec-tests/pull/223), and integration of these changes into [Pyspec Hive Simulator](https://github.com/ethereum/hive/tree/master/simulators/ethereum/pyspec) alongside the integration of other Deneb related tests.
- EF Testing Hub, collated links and relavent info on all testing efforts carried out within the ethereum ecosystem.

# Short summary of their work / eligibility
Spencer Taylor-Brown became a part of the EF testing team on January 9th, 2023. He has gained expertise in execution client testing, and is an active maintainer of the new execution-spec-tests repo, a significant tool that generates test fixtures for execution clients, and verifies client implementation of the spec modifications for each EIP in every upcoming Ethereum hardfork.

Additionally, Spencer is instrumental in the operation of the Pyspec Hive Simulator, where he utilizes the Engine API to facilitate execution client tests.

# Start date of relevant projects
January 9th, 2023

# Proposed weight (full or partial)
Full weight