### PR TITLE
update kev's weight to partial

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Discussion should be open for ~1 week to give members time to review and contrib
  | EF Portal | [Ognyan Genev](https://github.com/ogenev/) | 1 |
  | EF Portal | [Piper Merriam](https://github.com/pipermerriam/) | 1 |
  | EF Portal | [Nick Gheorghita](https://github.com/njgheorghita) | 1 |
- | EF Privacy & Scaling Explorations (PSE) | [Kevaundray](https://github.com/kevaundray/) | 1 |
+ | EF Privacy & Scaling Explorations (PSE) | [Kevaundray](https://github.com/kevaundray/) | .5 |
  | EF Protocol Support | [Danny Ryan](https://github.com/djrtwo/) | 1 |
  | EF Protocol Support | [Guru](https://github.com/gurukamath/) | 1 |
  | EF Protocol Support | [Mário Havel](https://github.com/taxmeifyoucan) | 1 |


### PR DESCRIPTION
Per discussion in the [discord](https://discordapp.com/channels/795514951376568391/1130913190423822376/1132771700157722625) @kevaundray is now partial-weight on the Stateless Consensus project. I'm making this PR at his request.