### PR TITLE
Propose Jimmy Chen

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ Discussion should be open for ~1 week to give members time to review and contrib
  | Lighthouse | [Pawan Dhananjay Ravi](https://github.com/pawanjay176/) | 1 |
  | Lighthouse | [Sean Anderson](https://github.com/realbigsean/) | 1 |
  | Lighthouse | [Anton Delaruelle](https://github.com/antondlr) | 1 |
+ | Lighthouse | [Jimmy Chen](https://github.com/jimmygchen) | 1 |
  | Lodestar | [Afri](https://github.com/q9f/) | 0.5 |
  | Lodestar | [Cayman Nava](https://github.com/wemeetagain/) | 1 |
  | Lodestar | [dapplion](https://github.com/dapplion/) | 1 |


### PR DESCRIPTION
Name: Jimmy Chen
Team: Lighthouse
Discord Handle: jimmygchen
Weight: Full

# EPF Member - November 2022 - March 2023

Began initial work in assisting the lighthouse client, I point out main commits for brevity:

- Compilation corrections (https://github.com/sigp/lighthouse/pull/3692)
- Improving our internal slot-clock testing infra (https://github.com/sigp/lighthouse/pull/3974)
- Addressing CI issues and port conflicts (https://github.com/sigp/lighthouse/pull/4134)

# Lighthouse Member - March 2023 - Present

Jimmy works as part of the core team working on various elements of the protocol. Along with misc enhancements and spec updates to the lighthouse client, Jimmy is also helping on the 4844 front. Some client-related PRs can be seen here:

- Improved attester balance caching (https://github.com/sigp/lighthouse/pull/4362)
- Improve head state shuffling an issue resulting from the mainnet instability (https://github.com/sigp/lighthouse/pull/4296)
- Reduce bandwidth over BN <-> VC API (https://github.com/sigp/lighthouse/pull/4170)
- Fix attestation withdrawals root mismatch (https://github.com/sigp/lighthouse/pull/4249)
- Improve client performance via rate limiting backfill sync (https://github.com/sigp/lighthouse/pull/3936)

A significant amount of work is also being done on our deneb branch which we will hopefully merge down soon. (References for work contributed here can be provided if requested). 