### PR TITLE
Add Kairat Abylkasymov from Erigon

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ Discussion should be open for ~1 week to give members time to review and contrib
  | Erigon | [Andrey Ashikhmin](https://github.com/yperbasis/) | 1 |
  | Erigon | [Daniel Lazarenko](https://github.com/battlmonstr/) | 0.5 |
  | Erigon | [Giulio Rebuffo](https://github.com/Giulio2002/) | 1 |
+ | Erigon | [Kairat Abylkasymov](https://github.com/racytech/) | 1 |
  | Erigon | [Michelangelo Riccobene](https://github.com/mriccobene/) | 0.5 |
  | Erigon | [Tullio Canepa](https://github.com/canepat/) | 1 |
  | Ethereum Cat Herders | [Pooja Ranjan](https://github.com/poojaranjan/) | 1 |


### PR DESCRIPTION
### Name
Add Kairat Abylkasymov / [@racytech](https://github.com/racytech)

### Team
[Erigon](https://github.com/ledgerwatch/erigon)

### Link to some work
https://github.com/ledgerwatch/erigon/commits?author=racytech

### Eligibility
Among other contributions, Kairat's implemented most of EIP-4844 in Erigon. Currently he is working on EOF.

## Start Date 
Kairat joined the Erigon team in July 2021.

### Proposed Weight
Full. Kairat works on Erigon 100% of his time.