### PR TITLE
Add Artem Tsebrovskii from Erigon

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ Discussion should be open for ~1 week to give members time to review and contrib
  | EF Testing | [Spencer Taylor-Brown](https://github.com/spencer-tb/) | 1 |
  | Erigon | [Alex Sharov](https://github.com/AskAlexSharov/) | 1 |
  | Erigon | [Andrey Ashikhmin](https://github.com/yperbasis/) | 1 |
+ | Erigon | [Artem Tsebrovskii](https://github.com/awskii/) | 1 |
  | Erigon | [Daniel Lazarenko](https://github.com/battlmonstr/) | 0.5 |
  | Erigon | [Giulio Rebuffo](https://github.com/Giulio2002/) | 1 |
  | Erigon | [Michelangelo Riccobene](https://github.com/mriccobene/) | 0.5 |


### PR DESCRIPTION
### Name
Artem Tsebrovskii / [@awskii](https://github.com/awskii)

### Team
[Erigon](https://github.com/ledgerwatch/erigon)

### Link to some work
https://github.com/ledgerwatch/erigon/commits?author=awskii

### Eligibility
Artem has been working on [Erigon 3](https://erigon.substack.com/p/merging-erigon-3-and-erigon-4-and), our strategic project to have state history with transaction-level granularity and optimized state sync for archive nodes.

## Start Date 
Artem joined the Erigon team in January 2022.

### Proposed Weight
Full. Artem works on Erigon 100% of his time.