### PR TITLE
Add Matthew Keil from Lodestar

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ Discussion should be open for ~1 week to give members time to review and contrib
  | Lodestar | [Cayman Nava](https://github.com/wemeetagain/) | 1 |
  | Lodestar | [dapplion](https://github.com/dapplion/) | 1 |
  | Lodestar | [Gajinder Singh](https://github.com/g11tech/) | 1 |
+ | Lodestar | [Matthew Keil](https://github.com/matthewkeil) | 1 |
  | Lodestar | [Nazar Hussain](https://github.com/nazarhussain/) | 1 |
  | Lodestar | [Nico Flaig](https://github.com/nflaig) | 1 |
  | Lodestar | [Phil Ngo](https://github.com/philknows/) | 1 |


### PR DESCRIPTION
Name / identifier: [Matthew Keil](https://github.com/matthewkeil)
Team: Lodestar
Start date of relevant projects: March 1, 2023
Proposed weight: Full (1.0)

## Short summary of their work / eligibility
Matthew started with us as a freelancer after Devcon Bogota 2022, then became a full-time contributor at Lodestar starting March 2023.

## Link to some work
Maintaining nodeJS bindings for c-kzg: https://github.com/ethereum/c-kzg-4844/pull/170
and actively continuing to update: https://github.com/ethereum/c-kzg-4844/pulls?q=is%3Apr+is%3Aclosed+author%3Amatthewkeil

Contributions to blst-ts: https://github.com/ChainSafe/blst-ts/pulls/matthewkeil
Contributions to Lodestar: https://github.com/ChainSafe/lodestar/pulls?q=is%3Apr+author%3Amatthewkeil+is%3Aclosed 