### PR TITLE
add Mike Neuder

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ Discussion should be open for ~1 week to give members time to review and contrib
  | EF Research | [Mark Simkin](https://github.com/msimkin.github.io/) | 1 |
  | EF Research | [Pop Chunhapanya](https://github.com/ppopth/) | 1 |
  | EF Research | [Zhenfei Zhang](https://github.com/zhenfeizhang/) | 0.5 |
+ | EF Research | [Mike Neuder](https://github.com/michaelneuder) | 1 |
  | EF Robust Incentives Group (RIG) | [Anders](https://github.com/anderselowsson/) | 1 |
  | EF Robust Incentives Group (RIG) | [Barnabé Monnot](https://github.com/barnabemonnot/) | 1 |
  | EF Robust Incentives Group (RIG) | [Caspar Schwarz-Schilling](https://github.com/casparschwa/) | 1 |


### PR DESCRIPTION
Name / identifier: [Mike Neuder](https://github.com/michaelneuder)
Team: EF Research
Start date of relevant projects: March 2023
Proposed weight: Full (1.0)

## Short summary of their work / eligibility

Mike has been working full-time for the Ethereum Foundation since March 2023. The initial research he worked on was around the mev-boost ecosystem and enshrined PBS (March-present). This led to discussions around the evolution of the consensus layer and the immediate goal of increasing the validator MAX_EFFECTIVE_BALANCE through EIP-7251 (June-present). Lately, with the increase in builder censorship, he has been working on the design of inclusion lists and how to avoid the provisioning of free data availability (August-present).

## Link to some work

- [Why enshrine Proposer-Builder Separation? A viable path to ePBS](https://ethresear.ch/t/why-enshrine-proposer-builder-separation-a-viable-path-to-epbs/15710)
- [Relays in a post-ePBS world](https://ethresear.ch/t/relays-in-a-post-epbs-world/16278)
- [Increase the MAX_EFFECTIVE_BALANCE – a modest proposal](https://ethresear.ch/t/increase-the-max-effective-balance-a-modest-proposal/15801)
- [No free lunch – a new inclusion list design](https://ethresear.ch/t/no-free-lunch-a-new-inclusion-list-design/16389)