### PR TITLE
Add Dan from EF Testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ Discussion should be open for ~1 week to give members time to review and contrib
  | EF Security | [Tyler Holmes](https://github.com/z3n-chada/) | 1 |
  | EF Security | [Yoav Weiss](https://github.com/yoavw/) | 1 |
  | EF Stateless Consensus| [Ignacio Hagopian](https://github.com/jsign/) | 1 |
+ | EF Testing | [danceratopz](https://github.com/danceratopz) | 1 |
  | EF Testing | [Mario Vega](https://github.com/marioevz/) | 1 |
  | EF Testing | [Spencer Taylor-Brown](https://github.com/spencer-tb/) | 1 |
  | Erigon | [Alex Sharov](https://github.com/AskAlexSharov/) | 1 |


### PR DESCRIPTION
## Name

Dan, aka [danceratopz](https://github.com/danceratopz).

## Team

Testing Team @ Ethereum Foundation

## Short summary of their work / eligibility

Dan became a part of the EF testing team in April, 2023. He has gained expertise in execution client testing and is an active maintainer of the relatively new [execution-spec-tests](https://github.com/ethereum/execution-spec-tests) repo.

Dan's main focus since starting has been the [execution-spec-tests](https://github.com/ethereum/execution-spec-tests) framework which generates test fixtures for execution clients focusing on upcoming protocol changes. This work includes a re-write of the framework test runner to use a standard Python test framework (pytest) that allows parametrization of tests, better test reporting and easier execution.

## Link to some work

### Code

- Maintainer of [execution-spec-tests](https://github.com/ethereum/execution-spec-tests):
    - Use pytest as a test runner:
        - [Proposal](https://hackmd.io/@danceratopz/rkrJtNQz3).
        - [execution-spec-tests#116 - feature: use pytest to collect and execute test fillers](https://github.com/ethereum/execution-spec-tests/pull/116).
    - Cancun testing:
        - EIP-1153 test cases (partially ported from ethereum/tests):
            - [execution-spec-tests#230 - EIP-1153 Transient Storage Tests](https://github.com/ethereum/execution-spec-tests/pull/230)
            - [execution-spec-tests#292 - tests: add more transient storage/eip-1153 tests ](https://github.com/ethereum/execution-spec-tests/pull/292)
            - [Test Case Reference doc](https://ethereum.github.io/execution-spec-tests/main/tests/cancun/eip1153_tstore/) / [Re-entrancy test cases](https://ethereum.github.io/execution-spec-tests/main/tests/cancun/eip1153_tstore/test_tstorage_reentrancy_contexts/index/test_cases/).
    - Added/helped add support for the Besu, Evmone, execution-specs and Nimbus transition tools. 
    - Revamped [doc pages](https://ethereum.github.io/execution-spec-tests/v1.0.6/), which include an automatically generated lists of parametrized test cases per EIP versioned by execution-spec-tests release. 

### Talks

- Co-presenting execution-spec-tests in [ACD execution layer meeting 164](https://www.youtube.com/live/09Kzi2x06UM?feature=share&t=148): https://notes.ethereum.org/@danceratopz/execution-spec-tests-overview-202306

### In progress / Planned

Currently working on:
- Executing `blocktest` to verify fixtures:
    - [execution-spec-tests#325 - feat(fw): run evm blocktest on generated fixtures](https://github.com/ethereum/execution-spec-tests/pull/325)
    - [execution-spec-tests#331 - feat(pytest): add option to write one fixture per json file](https://github.com/ethereum/execution-spec-tests/pull/331)

Planned:
- Enable configuration/execution of multiple `t8n` tools to allow test fixture generation from different EVM implementations with various features under development. 
- Allow easy testing of EELS-implemented EIPs within execution-spec-tests.
- Hive.

### Start date of relevant projects

April 1st, 2023

## Proposed weight (full or partial)

Full*

*Dan usually works 4 out of 5 days a week but he should still be considered full weight in my opinion, though it is worth mentioning since there is no 80% weight.