### PR TITLE
Add Somnath Banerjee from Erigon

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ Discussion should be open for ~1 week to give members time to review and contrib
  | Erigon | [lupin012](https://github.com/lupin012/) | 0.5 |
  | Erigon | [Kairat Abylkasymov](https://github.com/racytech/) | 1 |
  | Erigon | [Michelangelo Riccobene](https://github.com/mriccobene/) | 0.5 |
+ | Erigon | [Somnath Banerjee](https://github.com/somnathb1/) | 1 |
  | Erigon | [Tullio Canepa](https://github.com/canepat/) | 1 |
  | Ethereum Cat Herders | [Pooja Ranjan](https://github.com/poojaranjan/) | 1 |
  | Hyperledger Besu | [Ameziane](https://github.com/https://github.com/ahamlat/) | 1 |


### PR DESCRIPTION
### Name
Add Somnath Banerjee / [@somnathb1](https://github.com/somnathb1)

### Team
[Erigon](https://github.com/ledgerwatch/erigon)

### Link to some work
https://github.com/ledgerwatch/erigon/commits?author=somnathb1

### Eligibility
Among other contributions, Somnath added support of EIP-4844 to Erigon's transaction pool and fixed many Hive tests. Currently he is working on Verkle.

## Start Date 
Somnath joined the Erigon team on 1 June 2023.

### Proposed Weight
Full. Somnath works on Erigon 100% of his time.