### PR TITLE
Add Karim Taam (matkt) as a member of Protocol Guild

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Discussion should be open for ~1 week to give members time to review and contrib
  | Hyperledger Besu | [pinges](https://github.com/pinges/) | 1 |
  | Hyperledger Besu | [Sally Macfarlane](https://github.com/macfarla/) | 1 |
  | Hyperledger Besu | [Simon Dudley](https://github.com/siladu/) | 1 |
-| Hyperledger Besu | [Devrim (Karim Taam)](https://github.com/matkt/) | 1 |
+| Hyperledger Besu | [Karim Taam](https://github.com/matkt/) | 1 |
  | Independent | [Cheeky-gorilla](https://github.com/cheeky-gorilla) | 1 |
  | Independent | [Jim mcDonald](https://github.com/mcdee/) | 0.5 |
  | Lighthouse | [Adrian Manning](https://github.com/AgeManning/) | 0.5 |

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Discussion should be open for ~1 week to give members time to review and contrib
  | Hyperledger Besu | [pinges](https://github.com/pinges/) | 1 |
  | Hyperledger Besu | [Sally Macfarlane](https://github.com/macfarla/) | 1 |
  | Hyperledger Besu | [Simon Dudley](https://github.com/siladu/) | 1 |
- | Hyperledger Besu | [Karim Taam](https://github.com/matkt/) | 1 |
+| Hyperledger Besu | [Devrim (Karim Taam)](https://github.com/matkt/) | 1 |
  | Independent | [Cheeky-gorilla](https://github.com/cheeky-gorilla) | 1 |
  | Independent | [Jim mcDonald](https://github.com/mcdee/) | 0.5 |
  | Lighthouse | [Adrian Manning](https://github.com/AgeManning/) | 0.5 |

--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Discussion should be open for ~1 week to give members time to review and contrib
  | Hyperledger Besu | [pinges](https://github.com/pinges/) | 1 |
  | Hyperledger Besu | [Sally Macfarlane](https://github.com/macfarla/) | 1 |
  | Hyperledger Besu | [Simon Dudley](https://github.com/siladu/) | 1 |
+ | Hyperledger Besu | [Karim Taam](https://github.com/matkt/) | 1 |
  | Independent | [Cheeky-gorilla](https://github.com/cheeky-gorilla) | 1 |
  | Independent | [Jim mcDonald](https://github.com/mcdee/) | 0.5 |
  | Lighthouse | [Adrian Manning](https://github.com/AgeManning/) | 0.5 |


### PR DESCRIPTION
I suggest to add Karim Taam (GitHub handle: matkt), as a member of Protocol Guild. Karim was previously part of the guild but left temporarily, awaiting entity creation.

Karim has been working on Besu since July 11, 2019 https://github.com/hyperledger/besu/commits?author=matkt.

He has made substantial contributions to Bonsai, Snap sync, and numerous features in Besu. His notable achievements include the implementation of mechanisms to repair the flat database of Bonsai, which optimized block processing time. At present, he is actively working on the development of the Verkle Trie and resolving various bugs.

Karim would like to join Protocol Guild as a member but wishes to be excluded from Split V1. He wants to join the PG DAO once it is established.