### PR TITLE
Add Toni Wahrstätter

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ Discussion should be open for ~1 week to give members time to review and contrib
  | EF Research | [Mark Simkin](https://github.com/msimkin.github.io/) | 1 |
  | EF Research | [Mike Neuder](https://github.com/michaelneuder) | 1 |
  | EF Research | [Pop Chunhapanya](https://github.com/ppopth/) | 1 |
+ | EF Research | [Toni Wahrstätter](https://github.com/nerolation) | 1 |
  | EF Research | [Zhenfei Zhang](https://github.com/zhenfeizhang/) | 0.5 |
  | EF Robust Incentives Group (RIG) | [Anders](https://github.com/anderselowsson/) | 1 |
  | EF Robust Incentives Group (RIG) | [Barnabé Monnot](https://github.com/barnabemonnot/) | 1 |


### PR DESCRIPTION
Name / identifier: [Toni Wahrstätter](https://github.com/nerolation)
Team: EF ARG
Start date of relevant projects: 01/01/2023
Proposed weight: Full (1.0)

## Short summary of their work / eligibility

Toni has been working full-time for the Ethereum Foundation since November 2023 and has been an active contributor to the ecosystem since the start date above. Toni has contributed a series of invaluable data investigations via the [dotpics.info](https://dotpics.info/) sites, including https://mevboost.pics/ and https://censorship.pics/. These sites are live data visualizations of the Ethereum ecosystem that focus on understanding relevant issues that directly impact our community’s core values of neutrality and censorship resistance, especially via the lens of the growth of MEV supply chains as they relate to both off-chain and on-chain actors. Alongside this, Toni has been an active researcher in the privacy space working with Vitalik and others on the addition of [“stealth addresses”](https://eips.ethereum.org/EIPS/eip-5564) to the Ethereum protocol. Recently, he has been contributing to consensus research to harden the staking layer with focus in ePBS research. Refer to his posts on RANDAO manipulation and mev-burn for a sample here.

## Link to some work

* https://mevboost.pics/
* https://censorship.pics/
* https://dotpics.info/
* https://ethresear.ch/t/selfish-mixing-and-randao-manipulation/16081
* https://eips.ethereum.org/EIPS/eip-5564
* https://ethresear.ch/t/dr-changestuff-or-how-i-learned-to-stop-worrying-and-love-mev-burn/17384