### PR TITLE
Add Ben Adams from Nethermind (part-time)

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ Discussion should be open for ~1 week to give members time to review and contrib
  | Nethermind | [Ahmad Bitar](https://github.com/smartprogrammer93 ) | 0.5 |
  | Nethermind | [Alexey Osipov](https://github.com/flcl42) | 1 |
  | Nethermind | [Ayman Bouchareb](https://github.com/Demuirgos) | 1 |
+ | Nethermind | [Ben Adams](https://github.com/benaadams) | 0.5 |
  | Nethermind | [Daniel Celeda](https://github.com/dceleda/) | 1 |
  | Nethermind | [Jorge Mederos](https://github.com/jmederosalvarado/) | 0.5 |
  | Nethermind | [Kamil Chodoła](https://github.com/kamilchodola/) | 1 |


### PR DESCRIPTION
Name: [Ben Adams](https://github.com/benaadams)
Team: Nethermind
Discord: ben_a_adams
Link to relevant work: Contributions to the Nethermind Ethereum client https://github.com/NethermindEth/nethermind/pulls?q=is%3Apr+author%3Abenaadams+
Summary of their work/eligibility: Ben started independently contributing to Nethermind in December 2022 and joined the team officially in February 2023. He has been focused on performance, throughput, and memory reduction to reduce hardware requirements and improve attestations. Most recently he completely reimplemented the entire JSON RPC handling. Currently, he is looking into parallelizing the EVM, greater use of CPU intrinsics, JITing contracts to native code and Verkle Trie performance.