### PR TITLE
Add Joao Oliveira

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,7 @@ Discussion should be open for ~1 week to give members time to review and contrib
  | Lighthouse | [Sean Anderson](https://github.com/realbigsean/) | 1 |
  | Lighthouse | [Anton Delaruelle](https://github.com/antondlr) | 1 |
  | Lighthouse | [Jimmy Chen](https://github.com/jimmygchen) | 1 |
+ | Lighthouse | [João Oliveira](https://github.com/jxs) | 1 |
  | Lodestar | [Afri](https://github.com/q9f/) | 0.5 |
  | Lodestar | [Cayman Nava](https://github.com/wemeetagain/) | 1 |
  | Lodestar | [dapplion](https://github.com/dapplion/) | 1 |


### PR DESCRIPTION
Name / identifier: [Joao Oliveira](https://github.com/jxs)
Team: Lighthouse
Start date of relevant projects: 01/08/2023
Proposed weight: Full (1.0)

### Short summary of their work / eligibility

Joao started working on the Lighthouse client at the end of July 2023. His primary role is focused on the networking infrastructure of the Lighthouse client. His previous role was working on rust-libp2p and he continues work with us on the p2p infrastructure. 

Major recent contributions have been on diagnosing issues and performance problems with our gossipsub implementation and re-engineering the implementation to handle greater load, reduce memory and hopefully make it faster for the upcoming deneb fork. We are in the process of forking gossipsub from the base rust-libp2p repository to allow us to customize our implementation specifically for the Ethereum network. Below are some links to a list of the contributions he has recently added. 

https://github.com/sigp/lighthouse/commits/unstable?author=jxs
https://github.com/libp2p/rust-libp2p/commits/master/?author=jxs
https://github.com/sigp/rust-libp2p/commits/lighthouse-gossipsub?author=jxs

