### PR TITLE
Fix - add missing Ashraf

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ Discussion should be open for ~1 week to give members time to review and contrib
  | Nethermind | [Marcin Sobczak](https://github.com/marcindsobczak/) | 1 |
  | Nethermind | [Marek Moraczyński](https://github.com/MarekM25/) | 1 |
  | Nethermind | [Mateusz Jędrzejewski](https://github.com/matilote/) | 0.5 |
+ | Nethermind | [Muhammad Amirul Ashraf](https://github.com/asdacap) | 1 |
  | Nethermind | [Ruben Buniatyan](https://github.com/rubo/) | 0.5 |
  | Nethermind | [Tanishq Jasoria](https://github.com/tanishqjasoria/) | 1 |
  | Nethermind | [Tomasz Stanczak](https://github.com/tkstanczak/) | 0.5 |


### PR DESCRIPTION
This PR doesn't change membership as Ashraf is a member of PG, just fixing this members list after wrong conflict resolution.

Ashraf was added in this PR:  https://github.com/protocolguild/membership/pull/25

Then he was accidentally removed in this commit (due to conflict): https://github.com/protocolguild/membership/commit/9b9e8fe8aeca71bd1c90e0dfd06e0114c578538e