### PR TITLE
Add NC to Lodestar

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ Discussion should be open for ~1 week to give members time to review and contrib
  | Lodestar | [Cayman Nava](https://github.com/wemeetagain/) | 1 |
  | Lodestar | [Gajinder Singh](https://github.com/g11tech/) | 1 |
  | Lodestar | [Matthew Keil](https://github.com/matthewkeil) | 1 |
+ | Lodestar | [Navie Chan](https://github.com/ensi321) | 1 |
  | Lodestar | [Nazar Hussain](https://github.com/nazarhussain/) | 1 |
  | Lodestar | [Nico Flaig](https://github.com/nflaig) | 1 |
  | Lodestar | [Phil Ngo](https://github.com/philknows/) | 1 |

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ Discussion should be open for ~1 week to give members time to review and contrib
  | Lodestar | [Cayman Nava](https://github.com/wemeetagain/) | 1 |
  | Lodestar | [Gajinder Singh](https://github.com/g11tech/) | 1 |
  | Lodestar | [Matthew Keil](https://github.com/matthewkeil) | 1 |
- | Lodestar | [Navie Chan](https://github.com/ensi321) | 1 |
+ | Lodestar | [NC](https://github.com/ensi321) | 1 |
  | Lodestar | [Nazar Hussain](https://github.com/nazarhussain/) | 1 |
  | Lodestar | [Nico Flaig](https://github.com/nflaig) | 1 |
  | Lodestar | [Phil Ngo](https://github.com/philknows/) | 1 |


### PR DESCRIPTION
Name: NC
Team: Lodestar
Discord Handle: nc1234
Weight: Full

## Oct 2022 - Feb 2023: EPF
- Consensus client reward APIs [overview](https://github.com/kevinbogner/cohort-three/blob/master/projects/consensus_client_reward_APIs.md)
- block_rewards and attestation_rewards in Lighthouse https://github.com/sigp/lighthouse/pull/3907
- sync_committee_rewards in Lighthouse https://github.com/sigp/lighthouse/pull/3903

## Feb 2023: Reth
- Adding test support for several API module to Reth https://github.com/paradigmxyz/reth/pull/1288

## Mar 2023 - Jul 2023: EIP-6110 prototype
- Besu implementation https://github.com/hyperledger/besu/pull/5295, https://github.com/hyperledger/besu/pull/5055
[EIP-6110 PEEPanEIP](https://www.youtube.com/watch?v=tRTBgCN9VgY)

## May 2023: Erigon
- Diagnositc and debugging endpoints https://github.com/ledgerwatch/erigon/pull/7417, https://github.com/ledgerwatch/diagnostics/pull/10

## July 2023 - Today: Lodestar
- Implement EIP-6110 in Lodestar: https://github.com/ChainSafe/lodestar/pull/6042
- Add consensus_block_value to produceBlockV3: https://github.com/ChainSafe/lodestar/pull/6136
- Add response headers to produceBlockV3: https://github.com/ChainSafe/lodestar/pull/6228
- Add endpoint for Altair block reward: https://github.com/ChainSafe/lodestar/pull/6178
- Add proposer boost: https://github.com/ChainSafe/lodestar/pull/6298
- Add endpoint for sync committee reward: https://github.com/ChainSafe/lodestar/pull/6260