### PR TITLE
add Josh Rudolf

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ Discussion should be open for ~1 week to give members time to review and contrib
  | EF Security | [Tyler Holmes](https://github.com/z3n-chada/) | 1 |
  | EF Security | [Yoav Weiss](https://github.com/yoavw/) | 1 |
  | EF Stateless Consensus| [Ignacio Hagopian](https://github.com/jsign/) | 1 |
+ | EF Stateless Consensus| [Josh Rudolf](https://github.com/jrudolf/) | 1 |
  | EF Testing | [danceratopz](https://github.com/danceratopz) | 1 |
  | EF Testing | [Mario Vega](https://github.com/marioevz/) | 1 |
  | EF Testing | [Spencer Taylor-Brown](https://github.com/spencer-tb/) | 1 |


### PR DESCRIPTION
 * Name / identifier: Josh Rudolf / jrudolf
 * Team: Stateless Consensus
 * Link to some work: [verkle.info](https://verkle.info), [verkle implementer calls](https://github.com/ethereum/pm/issues?q=is%3Aissue+verkle+implementers+call) (open issue to read summary)
 * Short summary of their work / eligibility:
 
Through running the VIC and verkle.info, as well as contacting many teams, Josh has been instrumental in making the stateless ethreum effort more organized, as well as make it widely known in the community. He has been the interface between core dev teams, as well as other players in the ecosystem (L2s, dapps, ...), and is documenting conversations and decisions taken.
 
 * start date of relevant projects: August 2022
 * proposed weight: full