### PR TITLE
Add Dimitry from EF Testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ Discussion should be open for ~1 week to give members time to review and contrib
  | EF Security | [Tyler Holmes](https://github.com/z3n-chada/) | 1 |
  | EF Security | [Yoav Weiss](https://github.com/yoavw/) | 1 |
  | EF Stateless Consensus| [Ignacio Hagopian](https://github.com/jsign/) | 1 |
+ | EF Testing | [winsvega](https://github.com/winsvega) | 1 |
  | EF Testing | [danceratopz](https://github.com/danceratopz) | 1 |
  | EF Testing | [Mario Vega](https://github.com/marioevz/) | 1 |
  | EF Testing | [Spencer Taylor-Brown](https://github.com/spencer-tb/) | 1 |


### PR DESCRIPTION
 ## Name
Dimitry, aka [winsvega](https://github.com/winsvega).

## Team
Testing Team @ Ethereum Foundation

## Short summary of their work / eligibility
Dimitry was one of the first ethereum employees back in 2014.  He joined ethereum aleth team (back then cpp-ethereum) and worked on testeth application that was used that time to make first evm json tests such as Blockchain and State tests .jsons. 

After aleth discontinued, the testeth app was reformed as [retesteth](https://github.com/ethereum/retesteth) and was used to maintain, develop and generate all the test vectors from [tests](https://github.com/ethereum/tests) 

Dimitry has developed and supported most of the tests from that repo among with retesteth and later t8n tool protocol that is now used to generate the tests.  

## Link to some work
### Code
* Maintainer of [tests](github.com/ethereum/tests)
* Maintainer of [retesteth](https://github.com/ethereum/retesteth) http://retesteth.ethdevops.io/
* Pyspecs contributor [pyspecs](https://github.com/ethereum/execution-spec-tests/pulls?q=+is%3Apr+author%3Awinsvega+)
 
### Talks
[Shanghai Devcon: Testing ethereum consensus](https://archive.devcon.org/archive/watch/2/testing-ethereum-consensus/?playlist=Devcon%202)
[Cancun Devcon: Ethereum protocol testing](https://archive.devcon.org/archive/watch/3/ethereum-protocol-testing/?playlist=Devcon%203)
 
### In progress / Planned
Currently working on:
* Mastering python tests format [pyspecs prs](https://github.com/ethereum/execution-spec-tests/pulls?q=+is%3Apr+author%3Awinsvega+)
* Supporing .json/.yml test vector updates with all ethereum hard fork upgrades

Planned:
* Mastering python test format, contribute to execution-spec-tests development
* Converting existing .json/.yml tests into .py tests
* Updating existent .json/.yml tests to Cancun and beyond, untill it's converted into .py 

### Start date of relevant projects
December 1st, 2014 (EF team)
January 1st, 2024 (EF Testing team)
 
## Proposed weight (full or partial)
Full*
 
*Dimitry has 2 little kids growing up that influence his availability hours