### PR TITLE
Fix number of contributors in Wayfinding WG

### DIFF
--- a/docs/01-membership.md
+++ b/docs/01-membership.md
@@ -11,7 +11,7 @@ Individuals from active working groups produce the membership by opting into Pro
 
 ## WAYFINDING
 - Overview: the exploratory process to surface, describe and validate potential protocol changes
-- 10 Working Groups, 42 contributors
+- 10 Working Groups, 43 contributors
 - Venue: breakout calls
 - Artifacts: Research & POCs
 


### PR DESCRIPTION
There seem to be an incorrect calculation of the total number of contributors in Wayfinding WG: `5+2+7+2+7+6+1+7+2+4 == 43` not `42`