### PR TITLE
Remove Davide Crapis

### DIFF
--- a/docs/01-membership.md
+++ b/docs/01-membership.md
@@ -43,10 +43,9 @@ Individuals from active working groups produce the membership by opting into Pro
 | **Networking** (2 contributor) | | |
 | [Anton Nashatyrev](https://github.com/Nashatyrev/) | 1 | TXRX, [Consensys/teku](https://github.com/Consensys/teku/pulls?q=is%3Apr+author%3ANashatyrev), [ethereum/consensus-specs](https://github.com/ethereum/consensus-specs/pulls?q=is%3Apr+author%3ANashatyrev+), [libp2p/jvm-libp2p](https://github.com/libp2p/jvm-libp2p/pulls?q=is%3Apr+author%3ANashatyrev) |
 | [Pop Chunhapanya](https://github.com/ppopth/) | 1 | |
-| **Mechanism Design** (5 contributors) | | |
+| **Mechanism Design** (4 contributors) | | |
 | [Anders](https://github.com/anderselowsson/) | 1 | |
 | [Caspar Schwarz-Schilling](https://github.com/casparschwa/) | 1 | |
-| [Davide Crapis](https://github.com/dcrapis/) | 1 | |
 | [Julian Ma](https://github.com/Ma-Julian) | 1 | |
 | [Thomas Thiery](https://github.com/soispoke/) | 1 | [ethresear.ch/u/soispoke/summary](https://ethresear.ch/u/soispoke/summary/) |
 | **Prototyping** (6 contributors) | | |


### PR DESCRIPTION
Davide has moved on from Robust Incentives Group to starting a new team at the Ethereum Foundation: dAI. See announcement [here](https://x.com/DavideCrapis/status/1967573374911340975). 