### PR TITLE
Add Carlos Perez

### DIFF
--- a/docs/01-membership.md
+++ b/docs/01-membership.md
@@ -58,6 +58,7 @@ Individuals from active working groups produce the membership by opting into Pro
 | [Rahul](https://github.com/raxhvl) | 1 | [raxhvl/pglanding-raxhvl](https://github.com/raxhvl/pglanding-raxhvl) |
 | **Statelessness** (2 contributors) | | |
 | [Guillaume Ballet](https://github.com/gballet/) | 1 | [ethereum/go-ethereum](https://github.com/ethereum/go-ethereum/pulls?q=is%3Apr+author%3Agballet), [ethereum/go-verkle](https://github.com/ethereum/go-verkle/pulls?q=is%3Apr+author%3Agballet), [gballet/go-ethereum](https://github.com/gballet/go-ethereum/pulls?q=is%3Apr+author%3Agballet) |
+| [Ignacio Hagopian](https://github.com/jsign/) | 1 | [crate-crypto/go-ipa](https://github.com/crate-crypto/go-ipa/pulls?q=author%3A%22jsign%22), [ethereum/go-verkle](https://github.com/ethereum/go-verkle/pulls?q=author%3A%22jsign%22), [gballet/go-ethereum](https://github.com/gballet/go-ethereum/pulls?q=author%3A%22jsign%22) |
 | [Carlos Perez](https://github.com/CPerezz/) | 1 | [BloatNet](https://bloanet.info), [zkevm-circuits](https://github.com/privacy-ethereum/zkevm-circuits), [execution-spec-tests](https://github.com/ethereum/execution-spec-tests/pulls?q=author%3A%22CPerezz%22) [paradigmxyz/reth](https://github.com/paradigmxyz/reth/pulls?q=is%3Apr+author%3ACPerezz) [Halo2](https://github.com/privacy-ethereum/halo2/pulls?q=is%3Apr+author%3ACPerezz), [gballet/go-ethereum](https://github.com/gballet/go-ethereum/pulls?q=author%3A%22CPerezz%22) |
 | **Uncategorized** (3 contributors) | | |
 | [Josh Rudolf](https://github.com/jrudolf/) | 1 | |


### PR DESCRIPTION
Name: Carlos Perez (@CPerezz)
Team: Stateless Consensus
Start time: 2025-03
Weight: 1

Eligibility: Carlos has officially joined the Stateless Consensus teams at the EF in March 2025, although he had been contributing to the Ethereum Protocol long before that. His contributions prior to joining the team, includes working on the initial effort to create zkevms, from which the modern zkvm stems. His current work is just as foundational, working on some form of out-of-protocol state expiry (VOPS), leading the bloatnet effort, and helping with benchmarking the state-access instructions in order to determine their exact pricing.

Non-exhaustive list of his contributions:

 * [BloatNet](bloatnet.info) an effort to understand the impact of state growth
 * Co-Author in the [VOPS](https://ethresear.ch/t/a-pragmatic-path-towards-validity-only-partial-statelessness-vops/22236) proposal
 * https://github.com/privacy-ethereum/sonobe architect and lead developer of folding-schemes lib.
 * [Many contributions to halo2](https://github.com/privacy-ethereum/halo2/pulls?q=is%3Apr+author%3ACPerezz) and [halo2curves](https://github.com/privacy-ethereum/halo2curves/pulls?q=is%3Apr+author%3ACPerezz)
 * [zkvm explainer](https://hackmd.io/SJ0e7p_dS9y3ZIq-MmXm4Q) from one of the early inventors