### PR TITLE
Add Marc

### DIFF
--- a/docs/01-membership.md
+++ b/docs/01-membership.md
@@ -82,6 +82,7 @@ Individuals from active working groups produce the membership by opting into Pro
 | [Alex Stokes](https://github.com/ralexstokes/) | 1 | |
 | [Justin Traglia](https://github.com/jtraglia/) | 1 | [Consensys/teku](https://github.com/Consensys/teku/pulls?q=is%3Amerged+is%3Apr+author%3Ajtraglia), [ethereum/c-kzg-4844](https://github.com/ethereum/c-kzg-4844/pulls?q=is%3Amerged+is%3Apr+author%3Ajtraglia), [ethereum/consensus-specs](https://github.com/ethereum/consensus-specs/pulls?q=is%3Amerged+is%3Apr+author%3Ajtraglia), [prysmaticlabs/prysm](https://github.com/prysmaticlabs/prysm/pulls?q=is%3Amerged+is%3Apr+author%3Ajtraglia) |
 | [Mikhail Kalinin](https://github.com/mkalinin/) | 1 | TXRX, [ethresear.ch/u/mkalinin](https://ethresear.ch/u/mkalinin), [ethereum/EIPs](https://github.com/ethereum/EIPs/pulls?q=is%3Apr+author%3Amkalinin), [ethereum/consensus-specs](https://github.com/ethereum/consensus-specs/pulls?q=is%3Apr+author%3Amkalinin), [ethereum/execution-apis](https://github.com/ethereum/execution-apis/pulls?q=is%3Apr+author%3Amkalinin), [hackmd.io/@n0ble](https://hackmd.com/@n0ble) |
+| [Marc Garreau](https://github.com/wolovim/) | 1 | [ethereum/pm](https://github.com/ethereum/pm) |
 
 ## CLIENT IMPLEMENTATIONS
 - Overview: Implementations of the spec changes for each network upgrade, ongoing client maintenance and optimizations


### PR DESCRIPTION
Note: I believe this one and #407 should be under the Governance and Coordination category but it's divided between EL/CL. In both cases, they could share a single category but for now I added one to each. Suggestions and discussion are welcomed 

Name: Marc Garreau (@wolovim)
Team: Protocol Support
Start time: 2025-03
Weight: 1

Eligibility: Marc is part of Protocol Support team, mainly working on new tools and automation that helps to keep core development processes smooth. He has developed Forkcast from scratch, maintaining it technically, working on new features and also the content. He took over the maintenance of ACDbot which fixed by a complete refactor and keeps adding more stuff to automate. He also contributed to improving EIP process and continues to identify gaps we might need to work on. Marc has been in Ethereum development for a long time, previously working on Python tooling and even Mist and Grid before.  

Some of his contributions: 
- [Adding headliners](https://github.com/ethereum/pm/pull/1390)
- [Improving championing](https://github.com/ethereum/EIPs/pull/10391)
- [Forkcast](https://github.com/ethereum/forkcast)
- [ACD bot v2](https://github.com/ethereum/pm/pull/1649)
