### PR TITLE
Add Stefan Starflinger from ethPandaOps

### DIFF
--- a/docs/01-membership.md
+++ b/docs/01-membership.md
@@ -230,11 +230,11 @@ Individuals from active working groups produce the membership by opting into Pro
 
 ## UPGRADE DELIVERY
 - Overview: the process of bringing each bundle of spec changes to mainnet as a hard fork/upgrade
-- 5 Working Groups, 27 contributors
+- 5 Working Groups, 28 contributors
 - Venue: ACDT
 - Artifacts: Dev/testnets
 
-| **Dev/Testnets** (8 contributors) | Weight | Contributions |
+| **Dev/Testnets** (9 contributors) | Weight | Contributions |
 |:---|:---|:---|
 | [Andrew Davis](https://github.com/savid/) | 1 | [ethpandaops](https://github.com/ethpandaops) |
 | [Barnabas Busa](https://github.com/barnabasbusa/) | 1 | [ethpandaops](https://github.com/ethpandaops) |
@@ -244,6 +244,7 @@ Individuals from active working groups produce the membership by opting into Pro
 | [pk910](https://github.com/pk910/) | 1 | [ethpandaops](https://github.com/ethpandaops) |
 | [Rafael Matias](https://github.com/skylenet/) | 1 | [ethpandaops](https://github.com/ethpandaops) |
 | [Sam Calder-Mason](https://github.com/samcm/) | 1 | [ethpandaops](https://github.com/ethpandaops) |
+| [Stefan Starflinger](https://github.com/qu0b/) | 1 | [ethpandaops](https://github.com/ethpandaops) |
 | **Testing** (8 contributors) | | |
 | [Alex Vlasov](https://github.com/ericsson49/) | 1 | TXRX, [ethresear.ch/u/ericsson49](https://ethresear.ch/u/ericsson49), [ethereum/consensus-specs](https://github.com/ethereum/consensus-specs), [hackmd.io/@ericsson49](https://hackmd.io/@ericsson49) |
 | [danceratopz](https://github.com/danceratopz) | 1 | [ethereum/execution-spec-tests](https://github.com/ethereum/execution-spec-tests) |


### PR DESCRIPTION
**Name / Identifier**
Stefan / @qu0b

**Team / Project**
EF DevOps — ethPandaOps

**Start date of relevant projects**
September 2025

**Proposed weight**
Full (1.0)

**Summary of their work / eligibility**

Stefan joined the ethPandaOps team in September 2025 and quickly became a key contributor to our devnet coordination and operations efforts.

Since joining, Stefan has taken a leading role in coordinating and stabilizing Gloas devnets. He has been responsible for setting up and maintaining multiple devnet environments, working closely with client teams to diagnose and resolve complex cross-client issues. Through deep debugging and hands-on coordination, he played a significant role in driving unstable networks toward a reliable and production-ready bal-devnet.

Beyond operational coordination, Stefan has been highly active in improving the ethPandaOps tooling ecosystem. He has contributed to internal tooling and AI-assisted utilities that improve developer workflows, debugging efficiency, and overall operational visibility across networks.

Stefan has been working full time with the team and has already become an important part of devnet execution and client collaboration. Based on his ongoing contributions to Ethereum protocol development support and infrastructure, I would like to propose adding him to the Protocol Guild with a full weight of 1.0.

**Link to some work**

[BAL (Block Access List) Devnet Coordination](https://github.com/ethpandaops/bal-devnets/pulls?q=author%3Aqu0b+is%3Amerged) (set up and maintained devnet-0 through devnet-2)

Cross-client protocol bug fixes identified during devnet debugging:
- [Nethermind](https://github.com/NethermindEth/nethermind/pulls?q=author%3Aqu0b+is%3Amerged) (4 PRs — EIP-8024 off-by-one, cross-block state leaks, ExecutionPayloadV4)
- [Lodestar](https://github.com/ChainSafe/lodestar/pulls?q=author%3Aqu0b+is%3Amerged) (4 PRs — EIP-7843 slotNumber, data column sidecar, PeerManager)
- [Reth](https://github.com/paradigmxyz/reth/pulls?q=author%3Aqu0b+is%3Amerged) (3 PRs — EIP-7778 gas accounting, EIP-7843 slot_number, forkchoiceUpdatedV4)
- [alloy-rs/evm](https://github.com/alloy-rs/evm/pulls?q=author%3Aqu0b+is%3Amerged) (2 PRs — EIP-7778 gas, slot_number passthrough)
- [Lighthouse](https://github.com/sigp/lighthouse/pulls?q=author%3Aqu0b+is%3Amerged) (1 PR — Gloas slot_number in upgrade)
- [Nimbus](https://github.com/status-im/nimbus-eth1/pulls?q=author%3Aqu0b+is%3Amerged) (1 PR — gate EIP-8024 opcodes on Amsterdam)

[Ethereum execution-specs](https://github.com/ethereum/execution-specs/pulls?q=author%3Aqu0b+is%3Amerged) (5 PRs — EIP-7928 BAL test cases)

ethpandaops tooling contributions:
- [assertoor](https://github.com/ethpandaops/assertoor/pulls?q=author%3Aqu0b+is%3Amerged) (2 PRs — EEST migration, glamsterdam playbook)
- [ethereum-genesis-generator, ethereum-package, spamoor, dora, ethereum-metrics-exporter, hive-ui](https://github.com/search?q=org%3Aethpandaops+author%3Aqu0b+is%3Amerged&type=pullrequests)

Devnet infrastructure:
- [template-devnets](https://github.com/ethpandaops/template-devnets/pulls?q=author%3Aqu0b+is%3Amerged)
- [ansible-collection-general](https://github.com/ethpandaops/ansible-collection-general/pulls?q=author%3Aqu0b+is%3Amerged)

