### PR TITLE
Add Oleksii Bespalov from Nethermind

### DIFF
--- a/docs/01-membership.md
+++ b/docs/01-membership.md
@@ -201,7 +201,7 @@ Individuals from active working groups produce the membership by opting into Pro
 | [pinges](https://github.com/pinges/) | 1 | [hyperledger/besu](https://github.com/hyperledger/besu/pulls?q=author%3Apinges) |
 | [Sally Macfarlane](https://github.com/macfarla/) | 1 | [hyperledger/besu](https://github.com/hyperledger/besu/pulls?q=author%3Amacfarla) |
 | [Simon Dudley](https://github.com/siladu/) | 1 | [hyperledger/besu](https://github.com/hyperledger/besu/pulls?q=author%3Asiladu) |
-| **Nethermind** (15 contributors) | | [NethermindEth/nethermind](https://github.com/NethermindEth/nethermind) |
+| **Nethermind** (16 contributors) | | [NethermindEth/nethermind](https://github.com/NethermindEth/nethermind) |
 | [Ahmad Bitar](https://github.com/smartprogrammer93) | 0.5 | [NethermindEth/nethermind](https://github.com/NethermindEth/nethermind/pulls?q=author%3Asmartprogrammer93+) |
 | [Alexey Osipov](https://github.com/flcl42) | 1 | [NethermindEth/nethermind](https://github.com/flcl42?org=NethermindEth), [NethermindEth/nethermind](https://github.com/NethermindEth/nethermind/pulls/flcl42) |
 | [Anders Kristiansen](https://github.com/ak88) | 0.5 | [NethermindEth/nethermind](https://github.com/NethermindEth/nethermind/pulls?q=author%3Aak88) |
@@ -216,6 +216,7 @@ Individuals from active working groups produce the membership by opting into Pro
 | [Marek Moraczyński](https://github.com/MarekM25/) | 0.5 | [NethermindEth/nethermind](https://github.com/MarekM25?org=NethermindEth), [NethermindEth/nethermind](https://github.com/NethermindEth/nethermind/pulls?q=author%3AMarekM25) |
 | [Maksim Menshikov](https://github.com/maximmenshikov/) | 1 | [NethermindEth/riscv-alpine-build](https://github.com/NethermindEth/riscv-alpine-build), [NethermindEth/bflat-riscv64](https://github.com/NethermindEth/bflat-riscv64/tree/riscv64_zk), [NethermindEth/dotnet-riscv](https://github.com/nethermindeth/dotnet-riscv) |
 | [Muhammad Amirul Ashraf](https://github.com/asdacap) | 1 |[NethermindEth/nethermind](https://github.com/NethermindEth/nethermind/pulls?q=author%3Aasdacap) |
+| [Oleksii Bespalov](https://github.com/alexb5dh/) | 0.5 | [NethermindEth/nethermind](https://github.com/NethermindEth/nethermind/pulls?q=author%3Aalexb5dh) |
 | [Ruben Buniatyan](https://github.com/rubo/) | 0.5 | [NethermindEth/nethermind](https://github.com/NethermindEth/nethermind/pulls?q=author%3Arubo) |
 | **Reth** (7 contributors) | | [paradigmxyz/reth](https://github.com/paradigmxyz/reth) |
 | [Alexey Shekhirin](https://github.com/shekhirin/) | 0.5 | |


### PR DESCRIPTION
**Name / Identifier**
Oleksii / @alexb5dh 

**Team / Project**
Nethermind

**Start date of relevant projects**
May 2024*

**Proposed weight**
Half (0.5)

**Summary of their work / eligibility**

Oleksii joined Nethermind in February 2024, and in May 2024 joined the Core team and started working full-time on Nethermind Ethereum Client.

Some of his major contributions include:
- Implementation of [log index](https://github.com/NethermindEth/nethermind/pull/8464) infrastructure for efficient large range scans of `eth_getLogs` queries.
- [EIP/RIP-7212](https://github.com/NethermindEth/nethermind/pull/7135) (secp256r1 precompile) followed up with a [BoringSSL-based optimization](https://github.com/NethermindEth/nethermind/pull/8437).
- Introduction of [state override](https://github.com/NethermindEth/nethermind/pull/7362) parameter for `eth_call`/`eth_estimateGas`/`eth_createAccessList`.
- Adding [eth/69](https://github.com/NethermindEth/nethermind/pull/7052) protocol.

In October-November 2025 and January-February 2026 Oleksii focused on projects outside of PG eligibility.

Since March 2026 Oleksii came back working on Nethermind Ethereum Client, currently 50% capacity. At the moment he is focusing on triaging and fixing external security reports we are receiving - thus due to sensitive nature of his work it is currently less publicly visible.