### PR TITLE
Add Nikos Baxevanis from Protocol Security

### DIFF
--- a/docs/01-membership.md
+++ b/docs/01-membership.md
@@ -228,7 +228,7 @@ Individuals from active working groups produce the membership by opting into Pro
 
 ## UPGRADE DELIVERY
 - Overview: the process of bringing each bundle of spec changes to mainnet as a hard fork/upgrade
-- 5 Working Groups, 28 contributors
+- 5 Working Groups, 29 contributors
 - Venue: ACDT
 - Artifacts: Dev/testnets
 
@@ -255,11 +255,12 @@ Individuals from active working groups produce the membership by opting into Pro
 |**EthereumJS** (2 contributors)| | |
 | [Gabriel Rocheleau](https://github.com/gabrocheleau/) | 0.5 | [ethereum/ethereumjs-monorepo](https://github.com/ethereumjs/ethereumjs-monorepo/issues?q=author%3Agabrocheleau) |
 | [Scotty Poi](https://github.com/ScottyPoi/) | 0.5 | [ethereumjs/ethereumjs-monorepo](https://github.com/ethereumjs/ethereumjs-monorepo/pulls?q=is%3Apr+author%3Ascottypoi+), [ethereumjs/ultralight](https://github.com/ethereumjs/ultralight/pulls?q=is%3Apr+author%3Ascottypoi+) |
-| **Security** (6 contributors) | | |
+| **Security** (7 contributors) | | |
 | [Andrés Jiménez Láinez](https://github.com/nethoxa/) | 1 | [ethereum/protocol-security](https://github.com/ethereum/protocol-security/) |
 | [Antoine James](https://github.com/0xMushow) | 1 | [ethereum/protocol-security](https://github.com/ethereum/protocol-security/) |
 | [Bhargava Shastry](https://github.com/bshastry/) | 1 | [ethereum/protocol-security](https://github.com/ethereum/protocol-security/) |
 | [Fredrik](https://github.com/fredrik0x/) | 1 | [ethereum/protocol-security](https://github.com/ethereum/protocol-security/) |
+| [Nikos Baxevanis](https://github.com/moodmosaic/) | 1 | [ethereum/protocol-security](https://github.com/ethereum/protocol-security/) |
 | [Tyler Holmes](https://github.com/0xtylerholmes/) | 1 | [ethereum/protocol-security](https://github.com/ethereum/protocol-security/) |
 | [Yassine Ferhane](https://github.com/gitToki/) | 1 | [ethereum/protocol-security](https://github.com/ethereum/protocol-security/) |
 | **Funding + PG Operations** (3 contributors) | | |


### PR DESCRIPTION
**Name / Identifier**

Nikos Baxevanis / @moodmosaic

**Team / Project**

EF Protocol Security

**Start date of relevant projects**

October 1, 2025

**Proposed weight**

Full (1.0)

**Summary of their work / eligibility**

Nikos joined the EF Protocol Security at the beginning of October 2025. He has been leading the team's AI and fuzzing efforts to find security vulnerabilities in Ethereum clients. Since joining, Nikos has identified several important security issues in Lighthouse, Nethermind, and Besu. As an experienced security researcher, Nikos is helping guide others on the team too. While most of their work is private, Nikos is making the Ethereum protocol more secure.

**Links to some work**

* https://github.com/protocol-security/claude-swarm
* https://github.com/protocol-security/lightfuzz (private)
* https://github.com/protocol-security/netherfuzz (private)
* https://github.com/thomas-quadratic/besu/pull/2
* https://github.com/thomas-quadratic/besu/pull/4

**Link to all public GitHub contributions**

* https://github.com/pulls?q=author%3Amoodmosaic