### PR TITLE
Add Daniel Knopik from Lighthouse

### DIFF
--- a/docs/01-membership.md
+++ b/docs/01-membership.md
@@ -109,9 +109,10 @@ Individuals from active working groups produce the membership by opting into Pro
 | [Povilas Liubauskas](https://github.com/povi) | 1 | [grandinetech/grandine](https://github.com/grandinetech/grandine) |
 | [Saulius Grigaitis](https://github.com/sauliusgrigaitis) | 1 | [grandinetech/grandine](https://github.com/grandinetech/grandine) |
 | [Tumas](https://github.com/tumas) | 1 | [grandinetech/grandine](https://github.com/grandinetech/grandine) |
-| **Lighthouse** (12 contributors) | | [sigp/lighthouse](https://github.com/sigp/lighthouse) |
+| **Lighthouse** (13 contributors) | | [sigp/lighthouse](https://github.com/sigp/lighthouse) |
 | [Anton Delaruelle](https://github.com/antondlr) | 1 | [sigp/lighthouse](https://github.com/sigp/lighthouse/pulls?q=author%3Aantondlr) |
 | [Chee Keong Tan](https://github.com/chong-he/) | 1 | [sigp/lighthouse](https://github.com/sigp/lighthouse/pulls?q=author%3Achong-he) |
+| [Daniel Knopik](https://github.com/dknopik/) | 1 | [sigp/lighthouse](https://github.com/sigp/lighthouse/pulls?q=author%3Adknopik) |
 | [dapplion](https://github.com/dapplion/) | 1 | [ethereum/EIPs](https://github.com/ethereum/EIPs/pulls?q=author%3Adapplion), [ethereum/consensus-specs](https://github.com/ethereum/consensus-specs/pulls?q=author%3Adapplion), [sigp/lighthouse](https://github.com/sigp/lighthouse/pulls?q=author%3Adapplion) |
 | [Eitan Seri-Levi](https://github.com/eserilev/) | 1 | [sigp/lighthouse](https://github.com/sigp/lighthouse/pulls?q=author%3Aeserilev) |
 | [Jimmy Chen](https://github.com/jimmygchen) | 1 | [sigp/lighthouse](https://github.com/sigp/lighthouse/pulls?q=author%3Ajimmygchen) |


### PR DESCRIPTION
* Name: Daniel Knopik / [@dknopik](https://github.com/dknopik)
* Team: Lighthouse
* Start date:
  * Joined Sigma Prime in November 2024, primarily working on [Anchor](https://github.com/sigp/anchor) (Rust-based SSV client) and its integration with Lighthouse, while also contributing regularly to Lighthouse.
  * Transitioned to focus on Lighthouse in **October 2025**
* Proposed Weight: Full

**Summary of their work / eligibility:**

Daniel has been contributing to Lighthouse since September 2022, including early work on the [EIP-4844/Deneb blobs prototype](https://github.com/sigp/lighthouse/commit/8e4e499b5159c60fbde9ae0b8c03d8c910c402a0).

Since joining Sigma Prime in November 2024, he has continued to contribute directly to Lighthouse alongside this work. He also participated in the Fusaka interop and contributed to the PeerDAS implementation (e.g. https://github.com/sigp/lighthouse/pull/7588, https://github.com/sigp/lighthouse/pull/7582).

Since October 2025, his work has focused on Lighthouse, particularly around networking, including [PeerDAS partial messages](https://github.com/sigp/lighthouse/pull/8314) and contributing to our Gloas implementation (https://github.com/sigp/lighthouse/pull/9053, https://github.com/sigp/lighthouse/pull/9063, https://github.com/sigp/lighthouse/pull/9065). He now works exclusively on Lighthouse.