### PR TITLE
Add sukunrt to P2P Networking

### DIFF
--- a/docs/01-membership.md
+++ b/docs/01-membership.md
@@ -31,10 +31,11 @@ Individuals from active working groups produce the membership by opting into Pro
 | [George Kadianakis](https://github.com/asn-d6/) | 1 | |
 | [Gottfried Herold](https://github.com/GottfriedHerold) | 1 | |
 | [Thomas Coratger](https://github.com/tcoratger/) | 1 | [paradigmxyz/reth](https://github.com/paradigmxyz/reth/pulls?q=is%3Apr+author%3Atcoratger) [Plonky3/Plonky3](https://github.com/Plonky3/Plonky3/pulls?q=is%3Apr+author%3Atcoratger) [https://github.com/tcoratger/hashcaster-exploration](https://github.com/tcoratger/hashcaster-exploration) [zkevm book](eth-act.github.io/zkevm-book/) |
-| **P2P Networking** (3 contributors) | | |
+| **P2P Networking** (4 contributors) | | |
 | [Anton Nashatyrev](https://github.com/Nashatyrev/) | 1 | TXRX, [Consensys/teku](https://github.com/Consensys/teku/pulls?q=is%3Apr+author%3ANashatyrev), [ethereum/consensus-specs](https://github.com/ethereum/consensus-specs/pulls?q=is%3Apr+author%3ANashatyrev+), [libp2p/jvm-libp2p](https://github.com/libp2p/jvm-libp2p/pulls?q=is%3Apr+author%3ANashatyrev) |
 | [Marco Munizaga](https://github.com/MarcoPolo/) | 1 | |
 | [Raúl Kripalani](https://github.com/raulk/) | 1 | |
+| [Sukun](https://github.com/sukunrt/) | 1 | |
 |**Protocol Architecture** (4 contributors) | | |
 | [Ansgar Dietrichs](https://github.com/adietrichs/) | 1 | |
 | [Barnabé Monnot](https://github.com/barnabemonnot/) | 1 | |

--- a/docs/01-membership.md
+++ b/docs/01-membership.md
@@ -35,7 +35,7 @@ Individuals from active working groups produce the membership by opting into Pro
 | [Anton Nashatyrev](https://github.com/Nashatyrev/) | 1 | TXRX, [Consensys/teku](https://github.com/Consensys/teku/pulls?q=is%3Apr+author%3ANashatyrev), [ethereum/consensus-specs](https://github.com/ethereum/consensus-specs/pulls?q=is%3Apr+author%3ANashatyrev+), [libp2p/jvm-libp2p](https://github.com/libp2p/jvm-libp2p/pulls?q=is%3Apr+author%3ANashatyrev) |
 | [Marco Munizaga](https://github.com/MarcoPolo/) | 1 | |
 | [Raúl Kripalani](https://github.com/raulk/) | 1 | |
-| [Sukun](https://github.com/sukunrt/) | 1 | |
+| [Sukun Tarachandani](https://github.com/sukunrt/) | 1 | |
 |**Protocol Architecture** (4 contributors) | | |
 | [Ansgar Dietrichs](https://github.com/adietrichs/) | 1 | |
 | [Barnabé Monnot](https://github.com/barnabemonnot/) | 1 | |


### PR DESCRIPTION
**Name / Identifier**
Sukun Tarachandani / @sukunrt

**Team / Project**
EF P2P Networking

**Start date of relevant projects**
January 2025

**Proposed weight**
Full (1.0)

**Summary of their work / eligibility**

Sukun joined the EF in January 2025 and in October took on a grant to prototype erasure-coded broadcast strategies for Ethereum. He implemented Reed-Solomon and RLNC schemes from scratch, optimized the RS broadcaster in several ways, and built reproducible simulation frameworks on Shadow and simnet for benchmarking the two approaches against each other. This work served as one of the foundations for ethp2p/ethp2p.

Since then his scope has expanded to the rearchitecture of attestation and aggregation broadcast, where he is working closely with the Fast Finality team within the EF. Alongside this, he has continued maintaining libp2p/go-libp2p and gossipsub. I expect Sukun to continue expanding into future ethp2p areas including the transport, peering, and control plane layers.

**Links to work**

- [ethp2p/ethp2p](https://github.com/ethp2p/ethp2p) — erasure-coded broadcast, simulation frameworks, attestation broadcast rearchitecture
- [libp2p/go-libp2p](https://github.com/libp2p/go-libp2p/pulls?q=is%3Apr+author%3Asukunrt+is%3Amerged) — ongoing maintenance