### PR TITLE
Add kclowes from Testing

### DIFF
--- a/docs/01-membership.md
+++ b/docs/01-membership.md
@@ -243,11 +243,12 @@ Individuals from active working groups produce the membership by opting into Pro
 | [Rafael Matias](https://github.com/skylenet/) | 1 | [ethpandaops](https://github.com/ethpandaops) |
 | [Sam Calder-Mason](https://github.com/samcm/) | 1 | [ethpandaops](https://github.com/ethpandaops) |
 | [Stefan Starflinger](https://github.com/qu0b/) | 1 | [ethpandaops](https://github.com/ethpandaops) |
-| **Testing** (8 contributors) | | |
+| **Testing** (9 contributors) | | |
 | [Alex Vlasov](https://github.com/ericsson49/) | 1 | TXRX, [ethresear.ch/u/ericsson49](https://ethresear.ch/u/ericsson49), [ethereum/consensus-specs](https://github.com/ethereum/consensus-specs), [hackmd.io/@ericsson49](https://hackmd.io/@ericsson49) |
 | [danceratopz](https://github.com/danceratopz) | 1 | [ethereum/execution-spec-tests](https://github.com/ethereum/execution-spec-tests) |
 | [Felipe Selmo](https://github.com/fselmo/) | 1 | [ethereum/execution-spec-tests](https://github.com/ethereum/execution-spec-tests) |
-| [Felix Hoffmann](https://github.com/felix314159/) | 1 | [ethereum/execution-spec-tests](https://github.com/ethereum/execution-spec-tests) |
+| [Felix Hoffmann](https://github.com/felix314159/) | 1 | [ethereum/execution-specs](https://github.com/ethereum/execution-specs), [ethereum/execution-spec-tests](https://github.com/ethereum/execution-spec-tests) |
+| [Keri Clowes](https://github.com/kclowes) | 1 | [ethereum/execution-specs](), [ethereum/execution-spec-tests](ethereum/execution-spec-tests)
 | [Leo Lara](https://github.com/leolara) | 1 | [ethereum/consensus-specs](https://github.com/ethereum/consensus-specs) |
 | [Louis Tsai](https://github.com/LouisTsai-Csie/) | 1 | [ethereum/execution-specs](https://github.com/ethereum/execution-specs) |
 | [Mario Vega](https://github.com/marioevz/) | 1 | [ethereum/execution-spec-tests](https://github.com/ethereum/execution-spec-tests) |


### PR DESCRIPTION
# Add `kclowes` from STEEL

## Name

kclowes ([@kclowes](https://github.com/kclowes))

## Team

STEEL (EF)

## Short summary of their work / eligibility

- Full-time contributor to `ethereum/execution-specs` and `ethereum/execution-spec-tests`, focusing on test infrastructure. [execution-specs PRs](https://github.com/ethereum/execution-specs/pulls?q=is%3Apr+is%3Aclosed+author%3Akclowes) | [execution-spec-tests PRs](https://github.com/ethereum/execution-spec-tests/pulls?q=is%3Apr+is%3Aclosed+author%3Akclowes)
- Contributed to `ethereum/hive` RPC compatibility testing. [hive PRs](https://github.com/ethereum/hive/pulls?q=is%3Apr+is%3Aclosed+author%3Akclowes)
- Previously implemented EIPs in `ethereum/py-evm` including EIP-7702, EIP-3529, EIP-2565, demonstrating deep protocol knowledge. [PRs](https://github.com/ethereum/py-evm/pulls?q=is%3Apr+is%3Aclosed+author%3Akclowes)
- Authored EIP complexity assessments for ethsteel/pm (EIP-7668, EIP-8024).

## Link to some work

### ethereum/execution-specs & ethereum/execution-spec-tests

#### EIP-7951 P256VERIFY

- [#1410 - Move point at infinity check before curve check for p256 verify](https://github.com/ethereum/execution-specs/pull/1410) (Security fix for EIP-7951)
- [#2068 - feat(tests): Add contract creation tests for 7951](https://github.com/ethereum/execution-spec-tests/pull/2068)
- [#2023 - feat(tests): Add more cases for EIP-7951](https://github.com/ethereum/execution-spec-tests/pull/2023)
- [#2015 - feat(tests): Test 256verify modular comparison](https://github.com/ethereum/execution-spec-tests/pull/2015)
- [#2088 - chore(tests): Update 7951 Checklist Markers](https://github.com/ethereum/execution-spec-tests/pull/2088)

#### Infrastructure

- [#2301 - fix(rpc): Always set data on JSONRPCError, account for None](https://github.com/ethereum/execution-spec-tests/pull/2301)

### ethereum/hive

- [#1345 - simulators/ethereum/rpc-compat: special handling for speconly tests](https://github.com/ethereum/hive/pull/1345)

### ethsteel/pm

#### EIP Complexity Assessments

- [#13 - Complexity Assessment EIP-7668](https://github.com/ethsteel/pm/pull/13)
- [#10 - Initial EIP-8024 complexity assessment](https://github.com/ethsteel/pm/pull/10)
- [6758877 - EIP-7805](https://github.com/ethsteel/pm/commit/6758877)
- [3b1cc85 - EIP-8038](https://github.com/ethsteel/pm/commit/3b1cc85)
- [6b2c7cd - EIP-7843](https://github.com/ethsteel/pm/commit/6b2c7cd) 

### ethereum/py-evm

Prior maintainer.

#### EIP Implementations

- [#2206 - Finalize EIP-7702 implementation](https://github.com/ethereum/py-evm/pull/2206) — Prague (Set EOA Account Code)
- [#2200 - Begin 7702](https://github.com/ethereum/py-evm/pull/2200)
- [#2020 - EIP-3529 Reduction in Refunds](https://github.com/ethereum/py-evm/pull/2020)
- [#1976 - EIP-2565 ModExp Gas Cost](https://github.com/ethereum/py-evm/pull/1976)
- [#2015 - London basefee opcode 0x48](https://github.com/ethereum/py-evm/pull/2015)

## Start date of relevant projects

- First py-evm PRs: March 2021.
- Full-time execution-specs/execution-spec-tests contributor since June 2025.

## Proposed weight (full or partial)

Full

## Conflicts of Interest

None