### PR TITLE
Add joshieDo from Reth

### DIFF
--- a/docs/01-membership.md
+++ b/docs/01-membership.md
@@ -224,6 +224,7 @@ Individuals from active working groups produce the membership by opting into Pro
 | [DaniPopes](https://github.com/DaniPopes) | 0.5 | [paradigmxyz/reth](https://github.com/paradigmxyz/reth/pulls?q=is%3Apr+author%3Adanipopes+), [paradigmxyz/revmc](https://github.com/paradigmxyz/revmc) |
 | [Dragan Rakita](https://github.com/rakita/) | 1 | [bluealloy/revm](https://github.com/bluealloy/revm/commits/main/?author=rakita) |
 | [Federico Gimenez](https://github.com/fgimenez) | 0.5 | [paradigmxyz/reth](https://github.com/paradigmxyz/reth/commits?author=fgimenez) |
+| [joshieDo]([https://github.com/fgimenez](http://github.com/joshieDo)) | 0.5 | [paradigmxyz/reth](https://github.com/paradigmxyz/reth/commits?author=joshieDo) |
 | [Matthias Seitz](https://github.com/mattsse/) | 0.5 | |
 
 ## UPGRADE DELIVERY


### PR DESCRIPTION
@joshieDo is back to working on Reth

Previous PR: https://github.com/protocolguild/documentation/pull/143

- Name: joshie
- Github: @joshieDo
- Team: Reth
- Start date of relevant projects:
	- October 2022 - August 2023, Part (0.5)
	- September 2023 - April 2025, Full (1.0)
	- October 2025 - Now, Part (0.5)
- Short summary of their work/eligibility:
	- All from previous PR
	- [Storage V2 implementation](https://www.paradigm.xyz/2026/04/releasing-reth-2-0)
- Commits: [paradigmxyz/reth/commits?author=joshiedo](https://github.com/paradigmxyz/reth/commits?author=joshiedo)