### PR TITLE
Add Yann Vonlanthen from Protocol Consensus

### DIFF
--- a/docs/01-membership.md
+++ b/docs/01-membership.md
@@ -40,9 +40,10 @@ Individuals from active working groups produce the membership by opting into Pro
 | [Barnabé Monnot](https://github.com/barnabemonnot/) | 1 | |
 | [Francesco D’Amato](https://notes.ethereum.org/@fradamt/) | 1 | |
 | [Justin Drake](https://github.com/justindrake/) | 1 | |
-| **Protocol Consensus** (2 contributors) | | |
+| **Protocol Consensus** (3 contributors) | | |
 | [Luca Zanolini](https://github.com/luca-zanolini) | 1 | [luca-zanolini/research](https://github.com/luca-zanolini/research) |
 | [Roberto Saltini](https://github.com/saltiniroberto/) | 1 | [saltiniroberto/ethereum-research](https://github.com/saltiniroberto/ethereum-research/blob/main/README.md) |
+| [Yann Vonlanthen](https://github.com/yannvon) | 1 | |
 | **Protocol Prototyping** (7 contributors) | | |
 | [Bharath Vedartham](https://github.com/bharath-123/) | 1 | |
 | [Carl Beekhuizen](https://github.com/CarlBeek/) | 1 | |

--- a/docs/01-membership.md
+++ b/docs/01-membership.md
@@ -43,7 +43,7 @@ Individuals from active working groups produce the membership by opting into Pro
 | **Protocol Consensus** (3 contributors) | | |
 | [Luca Zanolini](https://github.com/luca-zanolini) | 1 | [luca-zanolini/research](https://github.com/luca-zanolini/research) |
 | [Roberto Saltini](https://github.com/saltiniroberto/) | 1 | [saltiniroberto/ethereum-research](https://github.com/saltiniroberto/ethereum-research/blob/main/README.md) |
-| [Yann Vonlanthen](https://github.com/yannvon) | 1 | |
+| [Yann Vonlanthen](https://github.com/yannvon) | 1 | [yannvonlanthen.com/publications](https://yannvonlanthen.com/publications/) |
 | **Protocol Prototyping** (7 contributors) | | |
 | [Bharath Vedartham](https://github.com/bharath-123/) | 1 | |
 | [Carl Beekhuizen](https://github.com/CarlBeek/) | 1 | |


### PR DESCRIPTION
- *Name / Identifier:* Yann Vonlanthen
- *Affiliated eligible project:* Protocol Consensus
- *Proposed weight:* 1
- *Start time*: 2025-08-01
- *Summary of contributions:* Yann joined the Protocol Consensus team full time on August 1, 2025. Since then, Yann has made significant contributions to the research and design of solutions to reduce both slot and finalization time for Ethereum. Before joining Protocol Consensus, Yann also conducted research into the security and anonymity of the Ethereum's p2p network.
- *Links to relevant eligible work, eg. GitHub, research*
    - [All You Need to Know About One-Round Finality](https://notes.ethereum.org/@yannvon/S1wIxIDqbe)
    - [Deanonymizing Ethereum Validators: The P2P Network Has a Privacy Issue](https://www.usenix.org/system/files/usenixsecurity25-heimbach.pdf) 
    - [Multiple Sides of 36 Coins: Measuring Peer-to-Peer Infrastructure Across Cryptocurrencies](https://arxiv.org/abs/2511.15388v1)
    - Coordinated the Fast Finality workshop at Devconnect & IC3
    - Presented on Ethereum Fast Finality and Networking at various conferences and workshops
        - [Ethereumzuri.ch'26 - The Road to Fast Finality](https://yannvonlanthen.com/assets/pdf/zuri26_fastfinality.pdf):
        - [FortMode'26 - The Road to Fast Finality](https://yannvonlanthen.com/assets/pdf/fortmode26_fastfinality.pdf)
        - [FC'26 - Majorum](https://yannvonlanthen.com/assets/pdf/fc26_majorum.pdf)
        - [UZH Summer School: 90min lecture on Ethereum](https://yannvonlanthen.com/assets/pdf/uzh25_ethereum.pdf) 
        - [IC3 - Kudzu: Fast and Simple High-Throughput BFT](https://yannvonlanthen.com/assets/pdf/ic3_kudzu.pdf)
        - [USENIX'25 Deanonymizing Ethereum Validators](https://yannvonlanthen.com/assets/pdf/usenix26_deanonymizing.pdf)
- Work yet to be published
    - Liveness favouring one-round protocols
    - Prefix-based one-round protocols