### PR TITLE
Add grapebaba from Lodestar Team

### DIFF
--- a/docs/01-membership.md
+++ b/docs/01-membership.md
@@ -122,9 +122,10 @@ Individuals from active working groups produce the membership by opting into Pro
 | [Michael Sproul](https://github.com/michaelsproul/) | 1 | [sigp/lighthouse](https://github.com/sigp/lighthouse/pulls?q=author%3Amichaelsproul) |
 | [Pawan Dhananjay Ravi](https://github.com/pawanjay176/) | 1 | [sigp/lighthouse](https://github.com/sigp/lighthouse/pulls?q=author%3Apawanjay176) |
 | [Sean Anderson](https://github.com/realbigsean/) | 0.5 | [sigp/lighthouse](https://github.com/sigp/lighthouse/pulls?q=author%3Arealbigsean) |
-| **Lodestar** (7 contributors) | | [ChainSafe/lodestar](https://github.com/ChainSafe/lodestar), [ChainSafe/lodestar-z](https://github.com/ChainSafe/lodestar-z) |
+| **Lodestar** (8 contributors) | | [ChainSafe/lodestar](https://github.com/ChainSafe/lodestar), [ChainSafe/lodestar-z](https://github.com/ChainSafe/lodestar-z) |
 | [Bing](https://github.com/spiral-ladder) | 1 | [ChainSafe/lodestar-z](https://github.com/ChainSafe/lodestar-z/pulls?q=author%3Aspiral-ladder) |
 | [Cayman Nava](https://github.com/wemeetagain/) | 1 | [ChainSafe/lodestar](https://github.com/ChainSafe/lodestar/pulls?q=author%3Awemeetagain) |
+| [grapebaba](https://github.com/grapebaba/) | 0.5 | [ChainSafe/lodestar-z](https://github.com/ChainSafe/lodestar-z/pulls?q=author%3Agrapebaba) |
 | [Matthew Keil](https://github.com/matthewkeil) | 1 | [ChainSafe/lodestar](https://github.com/ChainSafe/lodestar/pulls?q=author%3Amatthewkeil) |
 | [NC](https://github.com/ensi321) | 1 | [ChainSafe/lodestar](https://github.com/ChainSafe/lodestar/pulls?q=author%3Aensi321) |
 | [Nazar Hussain](https://github.com/nazarhussain/) | 1 | [ChainSafe/lodestar](https://github.com/ChainSafe/lodestar/pulls?q=author%3Anazarhussain) |


### PR DESCRIPTION
Name: GrapeBaBa (Kai Chen)
Team: Lodestar
Proposed Weight: 0.5
Start Date: Joined the Lodestar team part-time in October 2025 and has been integral to our Zig roadmap and optimization of the Lodestar client.  But before joining us GrapaBaBa has made significant contributions to the Ethereum Ecosystem over a much longer period of time.  He is brilliant, hardworking, deeply believes in the ethos of Ethereum and is a heck of a nice guy too!!

We are honored to nominate him to the Protocol Guild.  You can find a short selection of his eligible contributions below.

Links to Relevant Work:
- https://github.com/ethereum/go-ethereum/pull/31117
- https://github.com/ChainSafe/zig-discv5/pull/1
- https://github.com/ChainSafe/js-libp2p-gossipsub/pull/530
- https://github.com/ChainSafe/js-libp2p-gossipsub/pull/531
- https://github.com/ChainSafe/ssz-z/pull/85
- https://github.com/ChainSafe/lodestar-z/pull/81
- https://github.com/ChainSafe/lodestar-z/pull/100
- https://github.com/ChainSafe/lodestar-z/pull/104
- https://github.com/ChainSafe/lodestar-z/pull/109
- https://github.com/ChainSafe/lodestar-z/pull/138
- https://github.com/ChainSafe/lodestar-z/pull/227
- https://github.com/ChainSafe/lodestar-z/pull/246
- https://github.com/ChainSafe/lodestar/pull/9068
- https://github.com/ChainSafe/lodestar-z/pull/310