### PR TITLE
Add Willian Mitsuda from Erigon

### DIFF
--- a/docs/01-membership.md
+++ b/docs/01-membership.md
@@ -162,7 +162,7 @@ Individuals from active working groups produce the membership by opting into Pro
 
 | **EXECUTION CLIENTS** | Weight | Contributions |
 |:---|:---|:---|
-| **Erigon** (15 contributors) | | [erigontech/erigon](https://github.com/erigontech/erigon), [erigontech/zilkworm](https://github.com/erigontech/zilkworm) |
+| **Erigon** (16 contributors) | | [erigontech/erigon](https://github.com/erigontech/erigon), [erigontech/zilkworm](https://github.com/erigontech/zilkworm) |
 | [Alexey Sharov](https://github.com/AskAlexSharov/) | 1 | |
 | [Andrey Ashikhmin](https://github.com/yperbasis/) | 1 | [erigontech/erigon](https://github.com/erigontech/erigon/pulls?q=author%3Ayperbasis), [erigontech/silkworm](https://github.com/erigontech/silkworm/pulls?q=author%3Ayperbasis) |
 | [Artem Tsebrovskii](https://github.com/awskii/) | 1 | |
@@ -178,6 +178,7 @@ Individuals from active working groups produce the membership by opting into Pro
 | [lupin012](https://github.com/lupin012/) | 0.5 | [erigontech/erigon](https://github.com/erigontech/erigon/pulls?q=author%3Alupin012), [erigontech/rpc-tests](https://github.com/erigontech/rpc-tests/pulls?q=author%3Alupin012), [erigontech/silkworm](https://github.com/erigontech/silkworm/pulls?q=author%3Alupin012) |
 | [Matt Joiner](https://github.com/anacrolix/) | 1 | [erigontech/erigon](https://github.com/erigontech/erigon/pulls?q=author%3Aanacrolix) |
 | [Paweł Bylica](https://github.com/chfast/) | 1 | [ethereum/evmone](https://github.com/ethereum/evmone/commits?author=chfast) |
+| [Willian Mitsuda](https://github.com/wmitsuda/) | 1 | [erigontech/erigon](https://github.com/erigontech/erigon/pulls?q=author%3Awmitsuda) |
 | **Geth** (7 contributors) | | [ethereum/go-ethereum](https://github.com/ethereum/go-ethereum) |
 | [Bosul Mun](https://github.com/healthykim) | 1 | [ethereum/go-ethereum](https://github.com/ethereum/go-ethereum/pulls?q=is%3Apr+author%3Ahealthykim+) |
 | [Csaba Kiraly](https://github.com/cskiraly/) | 1 | [ethresear.ch/u/cskiraly](https://ethresear.ch/u/cskiraly/), [ethereum/go-ethereum](https://github.com/ethereum/go-ethereum/pulls?q=is%3Apr+author%3Acskiraly) |


### PR DESCRIPTION
- Name: Willian Mitsuda
- Team: Erigon
- Started Otterscan in 2021 and moved to Erigon core development in 2025
- Eligibility:
    - Willian is the author of https://github.com/otterscan/otterscan, a decentralized Ethereum block explorer.
    - He has made [significant improvements](https://erigon.tech/blog/how-i-reduced-a-polygon-archive-node-size-by-900gb/) to Erigon's snapshots.
    - Recently Willian has been working on optimizing Erigon performance in BloatNet/perf-devnet-3.
- Contributions: https://github.com/erigontech/erigon/pulls?q=author%3Awmitsuda, https://github.com/otterscan/otterscan
- Proposed Weight: Full (1.0)