### PR TITLE
Add Emma Jamieson-Hoare from Reth

### DIFF
--- a/docs/01-membership.md
+++ b/docs/01-membership.md
@@ -227,7 +227,7 @@ Individuals from active working groups produce the membership by opting into Pro
 | [Muhammad Amirul Ashraf](https://github.com/asdacap) | 1 |[NethermindEth/nethermind](https://github.com/NethermindEth/nethermind/pulls?q=author%3Aasdacap) |
 | [Oleksii Bespalov](https://github.com/alexb5dh/) | 0.5 | [NethermindEth/nethermind](https://github.com/NethermindEth/nethermind/pulls?q=author%3Aalexb5dh) |
 | [Ruben Buniatyan](https://github.com/rubo/) | 0.5 | [NethermindEth/nethermind](https://github.com/NethermindEth/nethermind/pulls?q=author%3Arubo) |
-| **Reth** (7 contributors) | **4.5** | [paradigmxyz/reth](https://github.com/paradigmxyz/reth) |
+| **Reth** (9 contributors) | **5.5** | [paradigmxyz/reth](https://github.com/paradigmxyz/reth) |
 | [Alexey Shekhirin](https://github.com/shekhirin/) | 0.5 | |
 | [Arsenii Kulikov](https://github.com/klkvr) | 0.5 | [paradigmxyz/reth](https://github.com/paradigmxyz/reth/pulls?q=is%3Apr+author%3Aklkvr) |
 | [Dan Cline](https://github.com/rjected/) | 1 | |

--- a/docs/01-membership.md
+++ b/docs/01-membership.md
@@ -233,6 +233,7 @@ Individuals from active working groups produce the membership by opting into Pro
 | [Dan Cline](https://github.com/rjected/) | 1 | |
 | [DaniPopes](https://github.com/DaniPopes) | 0.5 | [paradigmxyz/reth](https://github.com/paradigmxyz/reth/pulls?q=is%3Apr+author%3Adanipopes+), [paradigmxyz/revmc](https://github.com/paradigmxyz/revmc) |
 | [Dragan Rakita](https://github.com/rakita/) | 1 | [bluealloy/revm](https://github.com/bluealloy/revm/commits/main/?author=rakita) |
+| [Emma Jamieson-Hoare](https://github.com/emmajam/) | 0.5 | [paradigmxyz/reth](https://github.com/paradigmxyz/reth/pulls?q=is%3Apr+author%3Aemmajam+) |
 | [joshieDo]([https://github.com/fgimenez](http://github.com/joshieDo)) | 0.5 | [paradigmxyz/reth](https://github.com/paradigmxyz/reth/commits?author=joshieDo) |
 | [Matthias Seitz](https://github.com/mattsse/) | 0.5 | |
 


### PR DESCRIPTION
* Name: Emma Jamieson-Hoare
* Github: @emmajam
* Team: Reth
* Start date of relevant projects:
	* January 2026 - Now, Part (0.5)
* Short summary of their work/eligibility:
	* Core development / protocol coordination: represents Reth on ACDE, ACDT, and benchmarking calls; contributes across BAL/devnets, Engine/RPC behavior, P2P defaults, and Hive-related fixes: [#22772](https://github.com/paradigmxyz/reth/pull/22772), [#22777](https://github.com/paradigmxyz/reth/pull/22777), [#23737](https://github.com/paradigmxyz/reth/pull/23737), [#23686](https://github.com/paradigmxyz/reth/pull/23686), [#23225](https://github.com/paradigmxyz/reth/pull/23225), [#22374](https://github.com/paradigmxyz/reth/pull/22374), [#22007](https://github.com/paradigmxyz/reth/pull/22007)
	* Benchmarking / performance: maintains Reth benchmark infrastructure and regression visibility, including nightly benchmark uploads, release regression mode, benchmark notifications, and execution performance work: [#23344](https://github.com/paradigmxyz/reth/pull/23344), [#23416](https://github.com/paradigmxyz/reth/pull/23416), [#24039](https://github.com/paradigmxyz/reth/pull/24039), [#23617](https://github.com/paradigmxyz/reth/pull/23617)
	* Release management: manages Reth releases and release notes, including release branches, version bumps, and release pipeline fixes: [#21091](https://github.com/paradigmxyz/reth/pull/21091), [#21287](https://github.com/paradigmxyz/reth/pull/21287), [#22148](https://github.com/paradigmxyz/reth/pull/22148), [#22496](https://github.com/paradigmxyz/reth/pull/22496), [#22914](https://github.com/paradigmxyz/reth/pull/22914), [#23372](https://github.com/paradigmxyz/reth/pull/23372), [#23641](https://github.com/paradigmxyz/reth/pull/23641), [#23831](https://github.com/paradigmxyz/reth/pull/23831), [#25071](https://github.com/paradigmxyz/reth/pull/25071)
* Commits: [paradigmxyz/reth/commits?author=emmajam](https://github.com/paradigmxyz/reth/commits?author=emmajam)