### PR TITLE
Update Leo Lara contributions: add execution-specs

### DIFF
--- a/docs/01-membership.md
+++ b/docs/01-membership.md
@@ -260,7 +260,7 @@ Individuals from active working groups produce the membership by opting into Pro
 | [Felipe Selmo](https://github.com/fselmo/) | 1 | [ethereum/execution-spec-tests](https://github.com/ethereum/execution-spec-tests) |
 | [Felix Hoffmann](https://github.com/felix314159/) | 1 | [ethereum/execution-specs](https://github.com/ethereum/execution-specs), [ethereum/execution-spec-tests](https://github.com/ethereum/execution-spec-tests) |
 | [Keri Clowes](https://github.com/kclowes) | 1 | [ethereum/execution-specs](), [ethereum/execution-spec-tests](ethereum/execution-spec-tests)
-| [Leo Lara](https://github.com/leolara) | 1 | [ethereum/consensus-specs](https://github.com/ethereum/consensus-specs) |
+| [Leo Lara](https://github.com/leolara) | 1 | [ethereum/consensus-specs](https://github.com/ethereum/consensus-specs), [ethereum/execution-specs](https://github.com/ethereum/execution-specs) |
 | [Louis Tsai](https://github.com/LouisTsai-Csie/) | 1 | [ethereum/execution-specs](https://github.com/ethereum/execution-specs) |
 | [Mario Vega](https://github.com/marioevz/) | 1 | [ethereum/execution-spec-tests](https://github.com/ethereum/execution-spec-tests) |
 | [Spencer Taylor-Brown](https://github.com/spencer-tb/) | 1 | [ethereum/execution-spec-tests](https://github.com/ethereum/execution-spec-tests) |


### PR DESCRIPTION
Self-update to my membership entry.

I was recently laid off from the Ethereum Foundation (STEEL team) in the EF budget cuts, and I'm continuing eligible protocol work as an independent contributor. Weight and working group unchanged.

Adding `ethereum/execution-specs` to my contributions column, where most of my recent work has been (merged PRs through June 2026), alongside my earlier `ethereum/consensus-specs` work.

One question: I've also been contributing to `leanEthereum/leanSpec` (Lean Ethereum protocol specs + test vector generation framework, MIT-licensed). It doesn't look like Lean Ethereum is listed as an eligible project yet. Would it be appropriate for me to add it here, or should that go through a separate project-eligibility PR first? Happy to follow whichever process you prefer.
