### PR TITLE
Add Stavros Vlachakis from Nethermind

### DIFF
--- a/docs/01-membership.md
+++ b/docs/01-membership.md
@@ -210,7 +210,7 @@ Individuals from active working groups produce the membership by opting into Pro
 | [pinges](https://github.com/pinges/) | 1 | [hyperledger/besu](https://github.com/hyperledger/besu/pulls?q=author%3Apinges) |
 | [Sally Macfarlane](https://github.com/macfarla/) | 1 | [hyperledger/besu](https://github.com/hyperledger/besu/pulls?q=author%3Amacfarla) |
 | [Simon Dudley](https://github.com/siladu/) | 1 | [hyperledger/besu](https://github.com/hyperledger/besu/pulls?q=author%3Asiladu) |
-| **Nethermind** (16 contributors) | **12** | [NethermindEth/nethermind](https://github.com/NethermindEth/nethermind) |
+| **Nethermind** (16 contributors) | **12.5** | [NethermindEth/nethermind](https://github.com/NethermindEth/nethermind) |
 | [Ahmad Bitar](https://github.com/smartprogrammer93) | 0.5 | [NethermindEth/nethermind](https://github.com/NethermindEth/nethermind/pulls?q=author%3Asmartprogrammer93+) |
 | [Alexey Osipov](https://github.com/flcl42) | 1 | [NethermindEth/nethermind](https://github.com/flcl42?org=NethermindEth), [NethermindEth/nethermind](https://github.com/NethermindEth/nethermind/pulls/flcl42) |
 | [Anders Kristiansen](https://github.com/ak88) | 0.5 | [NethermindEth/nethermind](https://github.com/NethermindEth/nethermind/pulls?q=author%3Aak88) |
@@ -227,6 +227,7 @@ Individuals from active working groups produce the membership by opting into Pro
 | [Muhammad Amirul Ashraf](https://github.com/asdacap) | 1 |[NethermindEth/nethermind](https://github.com/NethermindEth/nethermind/pulls?q=author%3Aasdacap) |
 | [Oleksii Bespalov](https://github.com/alexb5dh/) | 0.5 | [NethermindEth/nethermind](https://github.com/NethermindEth/nethermind/pulls?q=author%3Aalexb5dh) |
 | [Ruben Buniatyan](https://github.com/rubo/) | 0.5 | [NethermindEth/nethermind](https://github.com/NethermindEth/nethermind/pulls?q=author%3Arubo) |
+| [Stavros Vlachakis](https://github.com/svlachakis) | 1 | [NethermindEth/nethermind](https://github.com/NethermindEth/nethermind/pulls?q=author%3Asvlachakis) |
 | **Reth** (7 contributors) | **4.5** | [paradigmxyz/reth](https://github.com/paradigmxyz/reth) |
 | [Alexey Shekhirin](https://github.com/shekhirin/) | 0.5 | |
 | [Arsenii Kulikov](https://github.com/klkvr) | 0.5 | [paradigmxyz/reth](https://github.com/paradigmxyz/reth/pulls?q=is%3Apr+author%3Aklkvr) |


### PR DESCRIPTION
Name / Identifier
Stavros Vlachakis

Team / Project
Nethermind

Start date of relevant projects
July 2025 (part-time)
February 2026 (full-time)

Proposed weight
Full (1.0)

Summary of work / eligibility

Stavros joined Nethermind in March 2025. Since July 2025, he has contributed part-time to the Nethermind Ethereum Execution Client (Core team) alongside other responsibilities. Since February 2026, he has worked full-time on Nethermind Client, with 100+ merged PRs in total. He owns the JSON-RPC for Nethermind Client. He is also expected to contribute extensively to Frame Transactions on Hegota.

Representative work:

- EIP-4444 history expiry (EraE): implemented the EraE archive format end-to-end — era export/import and remote download with SHA-256 verification. (#10812 (https://github.com/NethermindEth/nethermind/pull/10812))
- JSON-RPC (owner): broad spec-compliance and Geth-parity work plus new endpoints — e.g. Geth-compatible error codes (#11335 (https://github.com/NethermindEth/nethermind/pull/11335)) and eth_signTransaction / raw-transaction methods (#11517 (https://github.com/NethermindEth/nethermind/pull/11517), #11521 (https://github.com/NethermindEth/nethermind/pull/11521)).
- Streaming for large RPC responses: streaming approach for trace_* and debug_* results, avoiding buffering huge responses in memory. (#11755 (https://github.com/NethermindEth/nethermind/pull/11755), #11693 (https://github.com/NethermindEth/nethermind/pull/11693)).
- EVM & execution performance: eth_call interpreter/dispatch optimizations (#11965 (https://github.com/NethermindEth/nethermind/pull/11965)), EVM memory pooling and SLOAD / flat-state read caching (#11991 (https://github.com/NethermindEth/nethermind/pull/11991), #12043 (https://github.com/NethermindEth/nethermind/pull/12043)).
- State & consensus reliability: correct persisted-code tracking in the code DB (#11714 (https://github.com/NethermindEth/nethermind/pull/11714)), forkchoice canonical-chain corruption healing after beacon sync (#10876 (https://github.com/NethermindEth/nethermind/pull/10876)).

All merged PRs: https://github.com/NethermindEth/nethermind/pulls?q=is%3Apr+author%3Asvlachakis+is%3Aclosed (edited)