### PR TITLE
Add Daniil Ankushin from Nethermind

### DIFF
--- a/docs/01-membership.md
+++ b/docs/01-membership.md
@@ -210,13 +210,14 @@ Individuals from active working groups produce the membership by opting into Pro
 | [pinges](https://github.com/pinges/) | 1 | [hyperledger/besu](https://github.com/hyperledger/besu/pulls?q=author%3Apinges) |
 | [Sally Macfarlane](https://github.com/macfarla/) | 1 | [hyperledger/besu](https://github.com/hyperledger/besu/pulls?q=author%3Amacfarla) |
 | [Simon Dudley](https://github.com/siladu/) | 1 | [hyperledger/besu](https://github.com/hyperledger/besu/pulls?q=author%3Asiladu) |
-| **Nethermind** (16 contributors) | **12** | [NethermindEth/nethermind](https://github.com/NethermindEth/nethermind) |
+| **Nethermind** (17 contributors) | **13.5** | [NethermindEth/nethermind](https://github.com/NethermindEth/nethermind) |
 | [Ahmad Bitar](https://github.com/smartprogrammer93) | 0.5 | [NethermindEth/nethermind](https://github.com/NethermindEth/nethermind/pulls?q=author%3Asmartprogrammer93+) |
 | [Alexey Osipov](https://github.com/flcl42) | 1 | [NethermindEth/nethermind](https://github.com/flcl42?org=NethermindEth), [NethermindEth/nethermind](https://github.com/NethermindEth/nethermind/pulls/flcl42) |
 | [Anders Kristiansen](https://github.com/ak88) | 0.5 | [NethermindEth/nethermind](https://github.com/NethermindEth/nethermind/pulls?q=author%3Aak88) |
 | [Ben Adams](https://github.com/benaadams) | 1 | [NethermindEth/nethermind](https://github.com/NethermindEth/nethermind/pulls?q=author%3Abenaadams) |
 | [Carlos Bermudez Porto](https://github.com/cbermudez97) | 0.5 | [NethermindEth/nethermind](https://github.com/cbermudez97?org=NethermindEth), [NethermindEth/nethermind](https://github.com/NethermindEth/nethermind/pulls?q=author%3Acbermudez97+) |
 | [Damian Orzechowski](https://github.com/damian-orzechowski) | 0.5 | [NethermindEth/nethermind](https://github.com/NethermindEth/nethermind/pulls?q=author%3Adamian-orzechowski+) |
+| [Daniil Ankushin](https://github.com/AnkushinDaniil) | 1 | [NethermindEth/nethermind](https://github.com/NethermindEth/nethermind/pulls?q=author%3AAnkushinDaniil) |
 | [Kamil Chodoła](https://github.com/kamilchodola/) | 1 | [NethermindEth/nethermind](https://github.com/NethermindEth/nethermind/pulls?q=author%3Akamilchodola) |
 | [Łukasz Rozmej](https://github.com/LukaszRozmej/) | 1 | [NethermindEth/nethermind](https://github.com/LukaszRozmej?org=NethermindEth), [NethermindEth/nethermind](https://github.com/NethermindEth/nethermind/pulls?q=author%3ALukaszRozmej) |
 | [Marc Harvey-Hill](https://github.com/Marchhill) | 1 | [NethermindEth/nethermind](https://github.com/Marchhill?org=NethermindEth), [NethermindEth/nethermind](https://github.com/NethermindEth/nethermind/pulls?q=author%3AMarchhill) |


### PR DESCRIPTION
**Name / Identifier**
Daniil Ankushin / @AnkushinDaniil

**Team / Project**
Nethermind

**Start date of relevant projects**
November 2025

**Proposed weight**
Full (1)

**Summary of their work / eligibility**

Daniil has contributed to the Nethermind Ethereum execution client continuously since November 2025 and, since early 2026, on it alongside [State Benchmarks](https://nethermindeth.github.io/state-benchmarks/) research — measuring execution-layer performance from 1x up to 10x mainnet state to inform gas-limit (Glamsterdam) and statelessness (Hegotá) decisions.

He built the project's core client-side infrastructure: the StateComposition /[StateDiffsWriter](https://github.com/NethermindEth/nethermind/pull/11788) plugin that measures live trie-node composition per block, the [`testing_commitBlockV1`](https://github.com/NethermindEth/nethermind/pull/11385)
Engine-API write path used to build bloated states, and [`proof_getProofWithMeta`](https://github.com/NethermindEth/nethermind/pull/11498) for witness-size baselines. On the client itself he generified the EVM's
[VirtualMachine around policy-based gas tracking](https://github.com/NethermindEth/nethermind/pull/9846) 
He is also a core engineer on the benchmarking orchestration and cross-client replay tooling ([state-benchmarks](https://github.com/NethermindEth/state-benchmarks),
[eth-perf-research](https://github.com/NethermindEth/eth-perf-research)) and active across the project's research roadmap.

**Links to relevant eligible work**
- All Nethermind client PRs: https://github.com/NethermindEth/nethermind/pulls?q=author%3AAnkushinDaniil
- State Benchmarks: https://nethermindeth.github.io/state-benchmarks/
- GitHub: https://github.com/AnkushinDaniil