### PR TITLE
Set Ansgar Dietrichs weight to 0.5

### DIFF
--- a/docs/01-membership.md
+++ b/docs/01-membership.md
@@ -38,7 +38,7 @@ Individuals from active working groups produce the membership by opting into Pro
 | [Raúl Kripalani](https://github.com/raulk/) | 1 | |
 | [Sukun Tarachandani](https://github.com/sukunrt/) | 1 | |
 |**Protocol Architecture** (4 contributors) | **4** | |
-| [Ansgar Dietrichs](https://github.com/adietrichs/) | 1 | |
+| [Ansgar Dietrichs](https://github.com/adietrichs/) | 0.5 | |
 | [Barnabé Monnot](https://github.com/barnabemonnot/) | 1 | |
 | [Francesco D’Amato](https://notes.ethereum.org/@fradamt/) | 1 | |
 | [Justin Drake](https://github.com/justindrake/) | 1 | |


### PR DESCRIPTION
This PR reduces my weight to 0.5 for now.

Context: I moved from Ethereum Foundation to Ethlabs. I will continue my work as ACDE moderator and will at Ethlabs also spend time on core L1 protocol topics. The intention is to use this quarter to see how the time % spent practically turns out, and make further adjustments at the end of the quarter if necessary.