### PR TITLE
Add Francesco Risitano from zkEVM

### DIFF
--- a/docs/01-membership.md
+++ b/docs/01-membership.md
@@ -11,7 +11,7 @@ Individuals from active working groups produce the membership by opting into Pro
 
 ## WAYFINDING
 - Overview: the exploratory process to surface, describe and validate potential protocol changes
-- 9 Working Groups, 40 contributors, 40 total weight
+- 9 Working Groups, 41 contributors, 41 total weight
 - Venue: breakout calls
 - Artifacts: Research & POCs
 - Research Constraints
@@ -68,8 +68,9 @@ Individuals from active working groups produce the membership by opting into Pro
 | **Uncategorized** (2 contributors) | **2** | |
 | [Josh Rudolf](https://github.com/jrudolf/) | 1 | |
 | [Yoav Weiss](https://github.com/yoavw/) | 1 | [ethereum/protocol-security](https://github.com/ethereum/protocol-security/) |
-| **zkEVM** (4 contributors) | **4** | |
+| **zkEVM** (5 contributors) | **5** | |
 | [Cody Gunton](https://github.com/codygunton) | 1 | [zkevm-test-monitor](https://eth-act.github.io/zkevm-test-monitor/), [eth-act/cazkade](https://github.com/eth-act/cazkade), [risc0/risc0](https://github.com/risc0/risc0/), [risc0/zirgen](https://github.com/risc0/zirgen/pulls?q=is%3Apr+author%3Acodygunton+is%3Aclosed), [ethmag](https://ethereum-magicians.org/u/codygunton/activity), [ethresearch](https://ethresear.ch/t/before-jumping-on-the-riscv-bandwagon/22230/4)
+| [Francesco Risitano](https://github.com/frisitano/) | 1 | [EIP-8025](https://github.com/ethereum/EIPs/pull/11604), [EIP-8142 / BiB](https://eips.ethereum.org/EIPS/eip-8142), [EIP-8331](https://github.com/ethereum/EIPs/pull/11936), [consensus-specs](https://github.com/ethereum/consensus-specs/pulls?q=is%3Apr+author%3Afrisitano+8025), [Lighthouse optional proofs](https://github.com/eth-act/lighthouse/pulls?q=is%3Apr+author%3Afrisitano+eip8025) |
 | [Ignacio Hagopian](https://github.com/jsign/) | 1 | [ethereum/execution-specs](https://github.com/ethereum/execution-specs/pulls?q=author%3Ajsign) ([legacy repo](https://github.com/ethereum/execution-spec-tests/pulls?q=author%3Ajsign)), [paradigmxyz/reth](https://github.com/paradigmxyz/reth/pulls?q=author%3Ajsign), [eth-act/zkevm-benchmark-workload](https://github.com/eth-act/zkevm-benchmark-workload/pulls?q=author%3Ajsign), [eth-act/ere](https://github.com/eth-act/ere/pulls?q=author%3Ajsign), [eth-act/zkboost](https://github.com/eth-act/zkboost/pulls?q=author%3Ajsign) |
 | [Kevaundray Wedderburn](https://github.com/kevaundray/) | 1 | [zkEVM on L1](https://hackmd.io/@kevaundray/Bypupr9Yge) |
 | [TingHan Jian](https://github.com/han0110) | 1 | [eth-act/ere](https://github.com/eth-act/ere/pulls?q=is%3Apr+author%3Ahan0110+is%3Aclosed), [crate-crypto/rust-eth-kzg](https://github.com/crate-crypto/rust-eth-kzg/pulls?q=is%3Apr+author%3Ahan0110+is%3Aclosed), [privacy-ethereum/halo2](https://github.com/privacy-ethereum/halo2/pulls?q=is%3Apr+author%3Ahan0110)|


### PR DESCRIPTION
Name: Francesco Risitano

Team: EF Research Engineering (zkEVM project)

Started: Jan 2026

Eligibility / Contributions:

## EIPs Championed or Co-Authored

- [EIP-8025: Optional Execution Proofs](https://eips.ethereum.org/EIPS/eip-8025) - co-championed and co-authored. Drove the consensus side of EIP-8025 by defining the consensus specs and implementing EIP-8025 in the Lighthouse client, with corresponding Beacon API, Execution API, proof networking, and devnet work.
- [EIP-8142: Block-in-Blobs (BiB)](https://eips.ethereum.org/EIPS/eip-8142) & [EIP-8331: Partial Execution Payload Commitments](https://github.com/ethereum/EIPs/pull/11936/changes) -
  co-author, doing research related to architectural changes for improvement of the protocol.

## Slides and Writeups

- [EIP-8025: overview deck](https://frisitano.github.io/slides/presentations/eip-8025-overview/).
- [EIP-8025: ACDC proposal-for-inclusion deck](https://frisitano.github.io/slides/presentations/eip8025-acdc-proposal-2026-05-14/).
- [EIP-8025: optional proofs February update deck](https://frisitano.github.io/slides/presentations/optional-proofs-2026-02-11/).
- [EIP-8025: optional proofs March update deck](https://frisitano.github.io/slides/presentations/optional-proofs-2026-03-11/).
- [EIP-8025: optional proofs April update deck](https://frisitano.github.io/slides/presentations/optional-proofs-2026-04-08/).
- [EIP-8025: optional proofs May update deck](https://frisitano.github.io/slides/presentations/optional-proofs-2026-05-13/).
- [EIP-8025: optional proofs June update deck](https://frisitano.github.io/slides/presentations/optional-proofs-2026-06-10/).
- [EIP-8025: Lighthouse architecture writeup](https://frisitano.github.io/slides/writeups/eip8025-lighthouse-architecture.html).
- [EIP-8025: network announcement proof gossip writeup](https://frisitano.github.io/slides/writeups/eip8025-network-announcement-proof-gossip.html).
- [EIP-8025: validator proof resigning writeup](https://frisitano.github.io/slides/writeups/eip8025-validator-proof-resigning.html).
- [EIP-8025: weak-subjectivity checkpoint execution proof sync writeup](https://frisitano.github.io/slides/writeups/weak-subjectivity-checkpoint-proof-sync.html).
- [FV: EL-IR presentation](https://frisitano.github.io/slides/presentations/el-ir-evm-air-2026-06-09/).
- [FV: evm-sail overview deck](https://frisitano.github.io/slides/presentations/evm-sail-overview/).
- [PQ-DA: leanVM Fold-in-Circuit DAS deck](https://frisitano.github.io/slides/presentations/leanvm-fold-in-circuit-das-2026-05-08/).
- [PQ-DA: LeanAIR direct AIR construction writeup](https://frisitano.github.io/slides/writeups/leanair-construction-4-direct-air.html).
- [PQ-DA: pipelined blob proof dissemination writeup](https://frisitano.github.io/slides/writeups/pipelined-blob-proof-dissemination.html).

## PR / Code Evidence

### EIP-8025 / Optional Execution Proofs

- [ethereum/EIPs#11604](https://github.com/ethereum/EIPs/pull/11604)
- [ethereum/consensus-specs#5014](https://github.com/ethereum/consensus-specs/pull/5014)
- [ethereum/consensus-specs#5055](https://github.com/ethereum/consensus-specs/pull/5055)
- [ethereum/consensus-specs#5161](https://github.com/ethereum/consensus-specs/pull/5161)
- [ethereum/consensus-specs#5332](https://github.com/ethereum/consensus-specs/pull/5332)
- [ethereum/beacon-APIs#569](https://github.com/ethereum/beacon-APIs/pull/569)
- [ethereum/execution-apis#735](https://github.com/ethereum/execution-apis/pull/735)
- [ethereum/execution-apis#799](https://github.com/ethereum/execution-apis/pull/799)
- [All authored PRs in eth-act/lighthouse](https://github.com/eth-act/lighthouse/pulls?q=is%3Apr+author%3Afrisitano)

### zkEVM Devnet and Infrastructure


- [kurtosis-tech/kurtosis#3018](https://github.com/kurtosis-tech/kurtosis/pull/3018)
- [ethpandaops/ethereum-package#1353](https://github.com/ethpandaops/ethereum-package/pull/1353)
- [ethpandaops/ethereum-package#1363](https://github.com/ethpandaops/ethereum-package/pull/1363)
- [eth-act/lighthouse#23](https://github.com/eth-act/lighthouse/pull/23)

### Formal Execution Specification and zkVM Guest Work

- [frisitano/evm-sail](https://github.com/frisitano/evm-sail)

### Post-Quantum DA

- [leanEthereum/leanVM#224](https://github.com/leanEthereum/leanVM/pull/224)
- [LeanDA implementation](https://github.com/frisitano/leanMultisig/tree/232308f2711ee742cada68cca91aa93dfe379655/crates/lean-da)
- [LeanAIR implementation](https://github.com/frisitano/leanMultisig/tree/232308f2711ee742cada68cca91aa93dfe379655/crates/lean-air)

### Block-in-Blobs, EIP-8142, EIP-8331, and Execution-Stack Work

- [ethereum/consensus-specs#4847](https://github.com/ethereum/consensus-specs/pull/4847)
- [ethereum/execution-apis#736](https://github.com/ethereum/execution-apis/pull/736)
- [ethereum/EIPs#11936](https://github.com/ethereum/EIPs/pull/11936/changes)
- [ethereum/EIPs#11763](https://github.com/ethereum/EIPs/pull/11763)
- [ethereum/EIPs#11530](https://github.com/ethereum/EIPs/pull/11530)
- [ethereum/EIPs#11295](https://github.com/ethereum/EIPs/pull/11295)
- [ethereum/EIPs#11212](https://github.com/ethereum/EIPs/pull/11212)
