### PR TITLE
Add Ben Edgington from Protocol Consensus

### DIFF
--- a/docs/01-membership.md
+++ b/docs/01-membership.md
@@ -42,10 +42,11 @@ Individuals from active working groups produce the membership by opting into Pro
 | [Barnabé Monnot](https://github.com/barnabemonnot/) | 1 | |
 | [Francesco D’Amato](https://notes.ethereum.org/@fradamt/) | 1 | |
 | [Justin Drake](https://github.com/justindrake/) | 1 | |
-| **Protocol Consensus** (3 contributors) | **3** | |
+| **Protocol Consensus** (4 contributors) | **4** | |
 | [Luca Zanolini](https://github.com/luca-zanolini) | 1 | [luca-zanolini/research](https://github.com/luca-zanolini/research) |
 | [Roberto Saltini](https://github.com/saltiniroberto/) | 1 | [saltiniroberto/ethereum-research](https://github.com/saltiniroberto/ethereum-research/blob/main/README.md) |
 | [Yann Vonlanthen](https://github.com/yannvon) | 1 | [yannvonlanthen.com/publications](https://yannvonlanthen.com/publications/) |
+| [Ben Edgington](https://github.com/benjaminion) | 1 |  |
 | **Protocol Prototyping** (7 contributors) | **7** | |
 | [Bharath Vedartham](https://github.com/bharath-123/) | 1 | |
 | [Carl Beekhuizen](https://github.com/CarlBeek/) | 1 | |

--- a/docs/01-membership.md
+++ b/docs/01-membership.md
@@ -46,7 +46,7 @@ Individuals from active working groups produce the membership by opting into Pro
 | [Luca Zanolini](https://github.com/luca-zanolini) | 1 | [luca-zanolini/research](https://github.com/luca-zanolini/research) |
 | [Roberto Saltini](https://github.com/saltiniroberto/) | 1 | [saltiniroberto/ethereum-research](https://github.com/saltiniroberto/ethereum-research/blob/main/README.md) |
 | [Yann Vonlanthen](https://github.com/yannvon) | 1 | [yannvonlanthen.com/publications](https://yannvonlanthen.com/publications/) |
-| [Ben Edgington](https://github.com/benjaminion) | 1 |  |
+| [Ben Edgington](https://github.com/benjaminion) | 1 | [benjaminion.xyz](https://benjaminion.xyz/) |
 | **Protocol Prototyping** (7 contributors) | **7** | |
 | [Bharath Vedartham](https://github.com/bharath-123/) | 1 | |
 | [Carl Beekhuizen](https://github.com/CarlBeek/) | 1 | |


### PR DESCRIPTION
Name: Ben Edgington

Affiliation: Protocol Consensus

Weight: 1

Started: January 2026 (in this role)

Note: Ben is a former PG member, with a previous start date of January 2018 and end date of January 2024, so there are 24 inactive months to account for.

Contributions: This membership proposal is based on Ben's work facilitating the development and delivery of fast finality to Ethereum. Recent relevant work is showcased in [Upgrading Finality 1](https://consensus.ethereum.foundation/blog/upgrading-finality-edition-1) and [Upgrading Finality 2](https://consensus.ethereum.foundation/blog/upgrading-finality-edition-2). Other historic contributions can be found [here](https://benjaminion.xyz/).
